### PR TITLE
fix: remove rogue feature, not experiemental anymore

### DIFF
--- a/app/controllers/action_mcp/application_controller.rb
+++ b/app/controllers/action_mcp/application_controller.rb
@@ -332,7 +332,6 @@ module ActionMCP
       data = payload.is_a?(String) ? payload : MultiJson.dump(payload)
       sse_event = "id: #{event_id}\ndata: #{data}\n\n"
       sse.write(sse_event)
-      return unless ActionMCP.configuration.enable_sse_resumability
 
       begin
         session.store_sse_event(event_id, payload, session.max_stored_sse_events)
@@ -343,8 +342,6 @@ module ActionMCP
 
     # Helper to clean up old SSE events for a session
     def cleanup_old_sse_events(session)
-      return unless ActionMCP.configuration.enable_sse_resumability
-
       begin
         retention_period = session.sse_event_retention_period
         count = session.cleanup_old_sse_events(retention_period)

--- a/lib/action_mcp/configuration.rb
+++ b/lib/action_mcp/configuration.rb
@@ -29,7 +29,6 @@ module ActionMCP
                   # --- VibedIgnoreVersion Option ---
                   :vibed_ignore_version,
                   # --- SSE Resumability Options ---
-                  :enable_sse_resumability,
                   :sse_event_retention_period,
                   :max_stored_sse_events
 
@@ -46,7 +45,6 @@ module ActionMCP
       @vibed_ignore_version = false
 
       # Resumability defaults
-      @enable_sse_resumability = true
       @sse_event_retention_period = 15.minutes
       @max_stored_sse_events = 100
     end
@@ -140,9 +138,6 @@ module ActionMCP
       capabilities[:logging] = {} if @logging_enabled
 
       capabilities[:resources] = { subscribe: @resources_subscribe } if filtered_resources.any?
-
-      # Add resumability capability if enabled
-      capabilities[:resumability] = { enabled: @enable_sse_resumability } if @enable_sse_resumability
 
       capabilities
     end

--- a/test/controllers/action_mcp/application_controller_test.rb
+++ b/test/controllers/action_mcp/application_controller_test.rb
@@ -138,7 +138,6 @@ module ActionMCP
       assert_not_nil capabilities["prompts"], "Server should expose prompts capability"
       assert_not_nil capabilities["resources"]
       assert_not_nil capabilities["logging"]
-      assert_not_nil capabilities["resumability"]
 
       # Verify protocol version matches
       assert_equal "2025-03-26", init_response["result"]["protocolVersion"]

--- a/test/fixtures/action_mcp_sessions.yml
+++ b/test/fixtures/action_mcp_sessions.yml
@@ -1,4 +1,5 @@
-# Session fixtures for testing
+_fixture:
+  model_class: ActionMCP::Session
 
 # A basic initialized server session at step1
 step1_session:
@@ -14,6 +15,8 @@ step1_session:
   prompt_registry: '[]'
   resource_registry: '[]'
   sse_event_counter: 0
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
 
 # A server session at step2 of a workflow
 step2_session:
@@ -29,6 +32,8 @@ step2_session:
   prompt_registry: '[]'
   resource_registry: '[]'
   sse_event_counter: 0
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
 
 # A server session at final step of a workflow
 final_step_session:
@@ -44,6 +49,8 @@ final_step_session:
   prompt_registry: '[]'
   resource_registry: '[]'
   sse_event_counter: 0
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
 
 # A pre-initialized server session (for testing initialization process)
 pre_initialized_session:
@@ -59,6 +66,8 @@ pre_initialized_session:
   prompt_registry: '[]'
   resource_registry: '[]'
   sse_event_counter: 0
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
 
 # A closed server session  
 closed_session:
@@ -75,3 +84,5 @@ closed_session:
   prompt_registry: '[]'
   resource_registry: '[]'
   sse_event_counter: 3
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,10 @@ require "rails/test_help"
 
 require "action_mcp/test_helper"
 
+## Configure ActiveRecord Fixtures
+ActiveRecord::Migration.maintain_test_schema!
+ActiveSupport::TestCase.fixture_paths = [ File.expand_path("fixtures", __dir__) ]
+
 class MockOrder
   def self.find_by(id:)
     new(id: id) if id.to_i.positive?


### PR DESCRIPTION
Had this code for 2024 spec

But now the spec allow reusability by default