### PR TITLE
Fix SSE event trimming

### DIFF
--- a/app/models/action_mcp/session.rb
+++ b/app/models/action_mcp/session.rb
@@ -174,7 +174,7 @@ module ActionMCP
       count = sse_events.count
       excess = count - max_events
       if excess.positive?
-        sse_events.order(event_id: :asc).limit(excess).destroy_all
+        sse_events.order(event_id: :asc).limit(excess).delete_all
       end
 
       event

--- a/app/models/action_mcp/session.rb
+++ b/app/models/action_mcp/session.rb
@@ -171,7 +171,11 @@ module ActionMCP
       )
 
       # Maintain cache limit by removing oldest events if needed
-      sse_events.order(event_id: :asc).limit(sse_events.count - max_events).destroy_all if sse_events.count > max_events
+      count = sse_events.count
+      excess = count - max_events
+      if excess.positive?
+        sse_events.order(event_id: :asc).limit(excess).destroy_all
+      end
 
       event
     end


### PR DESCRIPTION
## Summary
- handle SSE event trimming more carefully

## Testing
- `bundle exec rake test` *(fails: could not find gem 'falcon' in locally installed gems)*