### PR TITLE
fix: configuration loading and profile merging

### DIFF
--- a/lib/action_mcp/server/base_session.rb
+++ b/lib/action_mcp/server/base_session.rb
@@ -147,7 +147,9 @@ module ActionMCP
 
       def cleanup_old_sse_events(max_age = 15.minutes)
         cutoff_time = Time.current - max_age
+        original_size = @sse_events.size
         @sse_events.delete_if { |e| e[:created_at] < cutoff_time }
+        original_size - @sse_events.size
       end
 
       def max_stored_sse_events

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ConfigurationTest < ActiveSupport::TestCase
+  setup do
+    @config = ActionMCP::Configuration.new
+  end
+
+  test "default configuration values" do
+    assert_equal true, @config.logging_enabled
+    assert_equal true, @config.list_changed
+    assert_equal :info, @config.logging_level
+    assert_equal false, @config.resources_subscribe
+    assert_equal :primary, @config.active_profile
+  end
+
+  test "default profiles are loaded" do
+    assert @config.profiles.key?(:primary)
+    assert @config.profiles.key?(:minimal)
+
+    # Primary profile defaults
+    assert_equal [ "all" ], @config.profiles[:primary][:tools]
+    assert_equal [ "all" ], @config.profiles[:primary][:prompts]
+    assert_equal [ "all" ], @config.profiles[:primary][:resources]
+
+    # Minimal profile defaults
+    assert_equal [], @config.profiles[:minimal][:tools]
+    assert_equal [], @config.profiles[:minimal][:prompts]
+    assert_equal [], @config.profiles[:minimal][:resources]
+  end
+
+  test "use_profile switches active profile" do
+    @config.use_profile(:minimal)
+    assert_equal :minimal, @config.active_profile
+  end
+
+  test "use_profile applies profile options" do
+    # Create a test profile with specific options
+    @config.profiles[:test_profile] = {
+      tools: [ "TestTool" ],
+      prompts: [],
+      resources: [],
+      options: {
+        list_changed: false,
+        logging_enabled: false,
+        logging_level: :warn
+      }
+    }
+
+    @config.use_profile(:test_profile)
+
+    assert_equal false, @config.list_changed
+    assert_equal false, @config.logging_enabled
+    assert_equal :warn, @config.logging_level
+  end
+
+  test "use_profile falls back to primary for non-existent profile" do
+    @config.use_profile(:non_existent)
+    assert_equal :primary, @config.active_profile
+  end
+
+  test "capabilities are generated based on profile content" do
+    @config.profiles[:test] = {
+      tools: [ "Tool1" ],
+      prompts: [ "Prompt1" ],
+      resources: [ "Resource1" ],
+      options: {
+        list_changed: true,
+        logging_enabled: true,
+        resources_subscribe: true
+      }
+    }
+
+    @config.use_profile(:test)
+    capabilities = @config.capabilities
+
+    assert capabilities[:tools]
+    assert_equal true, capabilities[:tools][:listChanged]
+
+    assert capabilities[:prompts]
+    assert_equal true, capabilities[:prompts][:listChanged]
+
+    assert capabilities[:resources]
+    assert_equal true, capabilities[:resources][:subscribe]
+    assert_equal true, capabilities[:resources][:listChanged]
+
+    assert capabilities[:logging]
+  end
+
+  test "empty arrays in profile don't generate capabilities" do
+    @config.profiles[:empty] = {
+      tools: [],
+      prompts: [],
+      resources: []
+    }
+
+    @config.use_profile(:empty)
+    capabilities = @config.capabilities
+
+    refute capabilities[:tools]
+    refute capabilities[:prompts]
+    refute capabilities[:resources]
+  end
+
+  test "should_include_all returns true for 'all' value" do
+    @config.profiles[:test] = {
+      tools: [ "all" ],
+      prompts: [ "specific" ],
+      resources: []
+    }
+
+    @config.use_profile(:test)
+
+    assert @config.send(:should_include_all?, :tools)
+    refute @config.send(:should_include_all?, :prompts)
+    refute @config.send(:should_include_all?, :resources)
+  end
+
+  test "authentication methods default based on environment" do
+    # In test environment
+    assert_equal [ "none" ], @config.authentication_methods
+  end
+
+  test "gateway class defaults to ApplicationGateway if available" do
+    if defined?(::ApplicationGateway)
+      assert_equal ::ApplicationGateway, @config.gateway_class
+    else
+      assert_equal ActionMCP::Gateway, @config.gateway_class
+    end
+  end
+
+  test "session store defaults based on environment" do
+    # In test environment
+    assert_equal :volatile, @config.session_store_type
+  end
+
+  test "client and server session store types fall back to global type" do
+    @config.session_store_type = :active_record
+
+    assert_equal :active_record, @config.client_session_store_type
+    assert_equal :active_record, @config.server_session_store_type
+  end
+
+  test "client and server session store types can be set independently" do
+    @config.client_session_store_type = :volatile
+    @config.server_session_store_type = :active_record
+
+    assert_equal :volatile, @config.client_session_store_type
+    assert_equal :active_record, @config.server_session_store_type
+  end
+
+  test "thread-local profile override" do
+    @config.use_profile(:primary)
+
+    # Set thread-local override
+    ActionMCP.thread_profiles.value = :minimal
+
+    assert_equal :minimal, @config.active_profile
+
+    # Clean up
+    ActionMCP.thread_profiles.value = nil
+  end
+
+  test "protocol version defaults" do
+    assert_equal "2025-03-26", @config.protocol_version
+  end
+
+  test "SSE configuration defaults" do
+    assert_equal 30, @config.sse_heartbeat_interval
+    assert_equal :json, @config.post_response_preference
+    assert_equal 15.minutes, @config.sse_event_retention_period
+    assert_equal 100, @config.max_stored_sse_events
+  end
+end

--- a/test/debug_error_code_test.rb
+++ b/test/debug_error_code_test.rb
@@ -6,7 +6,7 @@ class DebugErrorCodeTest < ActionDispatch::IntegrationTest
   fixtures :action_mcp_sessions
 
   setup do
-    @session = action_mcp_sessions(:test_session)
+    @session = action_mcp_sessions(:step1_session)  # Use initialized session
 
     # Ensure session is in the session store
     store = ActionMCP::Server.session_store

--- a/test/debug_init_test.rb
+++ b/test/debug_init_test.rb
@@ -4,6 +4,10 @@ require "test_helper"
 
 class DebugInitTest < ActionDispatch::IntegrationTest
   setup do
+    # Ensure configuration is properly loaded before creating sessions
+    ActionMCP.configuration.name = "ActionMCP Dummy"
+    ActionMCP.configuration.load_profiles
+
     # Create session through the session store (since this is testing initialization)
     session_store = ActionMCP::Server.session_store
     @session = session_store.create_session(nil, {

--- a/test/dummy/config/test_mcp.yml
+++ b/test/dummy/config/test_mcp.yml
@@ -1,0 +1,6 @@
+---
+test:
+  profiles:
+    custom:
+      tools:
+      - MyTool

--- a/test/integration/configuration_integration_test.rb
+++ b/test/integration/configuration_integration_test.rb
@@ -1,0 +1,389 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ConfigurationIntegrationTest < ActiveSupport::TestCase
+  setup do
+    @original_config_path = Rails.root.join("config", "mcp.yml")
+    @backup_path = Rails.root.join("config", "mcp.yml.backup")
+
+    # Backup existing config if it exists
+    if File.exist?(@original_config_path)
+      FileUtils.cp(@original_config_path, @backup_path)
+    end
+
+    # Reset ActionMCP configuration
+    ActionMCP.instance_variable_set(:@configuration, nil)
+
+    # Clear Rails config cache more thoroughly
+    # Rails caches config_for results in @configurations
+    if Rails.application.instance_variable_defined?(:@configurations)
+      Rails.application.instance_variable_set(:@configurations, {})
+    end
+
+    # Also clear the env_config cache
+    if Rails.application.config.instance_variable_defined?(:@configurations)
+      Rails.application.config.instance_variable_set(:@configurations, {})
+    end
+  end
+
+  teardown do
+    # Restore original config
+    if File.exist?(@backup_path)
+      FileUtils.mv(@backup_path, @original_config_path)
+    else
+      FileUtils.rm_f(@original_config_path)
+    end
+
+    # Reset configuration
+    ActionMCP.instance_variable_set(:@configuration, nil)
+  end
+
+  test "loads and merges profiles from YAML configuration" do
+    # Create a real YAML config file
+    config_content = {
+      "shared" => {
+        "authentication" => [ "none" ],
+        "profiles" => {
+          "primary" => {
+            "tools" => [ "CustomTool" ],
+            "options" => {
+              "list_changed" => false
+            }
+          },
+          "custom" => {
+            "tools" => [ "SpecialTool" ],
+            "prompts" => [],
+            "resources" => []
+          }
+        }
+      },
+      "test" => {
+        "adapter" => "test"
+      }
+    }
+
+    File.write(@original_config_path, YAML.dump(config_content))
+
+    # Force configuration reload
+    ActionMCP.instance_variable_set(:@configuration, nil)
+
+    # Force ActionMCP to reload configuration
+    config = ActionMCP.configuration
+    config.load_profiles
+
+    # Verify profiles were merged correctly
+    assert config.profiles.key?(:primary)
+    assert config.profiles.key?(:custom)
+    assert config.profiles.key?(:minimal), "Default minimal profile should still exist"
+
+    # Check that primary profile was merged, not replaced
+    assert_equal [ "CustomTool" ], config.profiles[:primary][:tools]
+    assert_equal [ "all" ], config.profiles[:primary][:prompts], "Prompts should retain default"
+    assert_equal [ "all" ], config.profiles[:primary][:resources], "Resources should retain default"
+    assert_equal false, config.profiles[:primary][:options][:list_changed]
+
+    # Verify custom profile
+    assert_equal [ "SpecialTool" ], config.profiles[:custom][:tools]
+  end
+
+  test "loads active profile from YAML configuration" do
+    config_content = {
+      "shared" => {
+        "authentication" => [ "none" ],
+        "profiles" => {
+          "primary" => {
+            "tools" => [ "all" ],
+            "prompts" => [ "all" ],
+            "resources" => [ "all" ]
+          },
+          "custom_profile" => {
+            "tools" => [ "MyTool" ],
+            "prompts" => [],
+            "resources" => []
+          }
+        }
+      },
+      "test" => {
+        "profile" => "custom_profile"
+      }
+    }
+
+    File.write(@original_config_path, YAML.dump(config_content))
+
+    # Force configuration reload
+    ActionMCP.instance_variable_set(:@configuration, nil)
+    config = ActionMCP.configuration
+    config.load_profiles
+
+    assert_equal :custom_profile, config.active_profile
+  end
+
+  test "capabilities reflect loaded profile configuration" do
+    config_content = {
+      "shared" => {
+        "authentication" => [ "none" ],
+        "profiles" => {
+          "primary" => {
+            "tools" => [ "TestTool" ],
+            "prompts" => [ "TestPrompt" ],
+            "resources" => [ "TestResource" ],
+            "options" => {
+              "list_changed" => true,
+              "logging_enabled" => true,
+              "resources_subscribe" => true
+            }
+          }
+        }
+      },
+      "test" => {}
+    }
+
+    File.write(@original_config_path, YAML.dump(config_content))
+
+    # Force configuration reload
+    ActionMCP.instance_variable_set(:@configuration, nil)
+    config = ActionMCP.configuration
+    config.load_profiles
+    capabilities = config.capabilities
+
+    assert capabilities[:tools], "Tools capability should be present"
+    assert_equal true, capabilities[:tools][:listChanged]
+
+    assert capabilities[:prompts], "Prompts capability should be present"
+    assert_equal true, capabilities[:prompts][:listChanged]
+
+    assert capabilities[:resources], "Resources capability should be present"
+    assert_equal true, capabilities[:resources][:subscribe]
+    assert_equal true, capabilities[:resources][:listChanged]
+
+    assert capabilities[:logging], "Logging capability should be present"
+  end
+
+  test "handles missing configuration file gracefully" do
+    # Ensure no config file exists
+    FileUtils.rm_f(@original_config_path)
+
+    # Should not raise an error
+    config = ActionMCP.configuration
+    config.load_profiles
+
+    # Should use defaults
+    assert config.profiles.key?(:primary)
+    assert config.profiles.key?(:minimal)
+    assert_equal :primary, config.active_profile
+  end
+
+  test "loads authentication methods from environment-specific config" do
+    config_content = {
+      "shared" => {
+        "authentication" => [ "jwt" ],
+        "profiles" => {
+          "primary" => {
+            "tools" => [ "all" ],
+            "prompts" => [ "all" ],
+            "resources" => [ "all" ]
+          }
+        }
+      },
+      "test" => {
+        "authentication" => [ "oauth", "jwt" ]
+      }
+    }
+
+    File.write(@original_config_path, YAML.dump(config_content))
+
+    # Force configuration reload
+    ActionMCP.instance_variable_set(:@configuration, nil)
+    config = ActionMCP.configuration
+    config.load_profiles
+
+    assert_equal [ "oauth", "jwt" ], config.authentication_methods
+  end
+
+  test "loads OAuth configuration from YAML" do
+    config_content = {
+      "shared" => {
+        "authentication" => [ "oauth" ],
+        "oauth" => {
+          "provider" => "test_oauth_provider",
+          "scopes_supported" => [ "mcp:tools", "mcp:resources" ],
+          "enable_dynamic_registration" => true,
+          "issuer_url" => "https://example.com"
+        },
+        "profiles" => {
+          "primary" => {
+            "tools" => [ "all" ],
+            "prompts" => [ "all" ],
+            "resources" => [ "all" ]
+          }
+        }
+      },
+      "test" => {}
+    }
+
+    File.write(@original_config_path, YAML.dump(config_content))
+
+    # Force configuration reload
+    ActionMCP.instance_variable_set(:@configuration, nil)
+    config = ActionMCP.configuration
+    config.load_profiles
+
+    assert_equal "test_oauth_provider", config.oauth_config["provider"]
+    assert_equal [ "mcp:tools", "mcp:resources" ], config.oauth_config["scopes_supported"]
+    assert_equal true, config.oauth_config["enable_dynamic_registration"]
+    assert_equal "https://example.com", config.oauth_config["issuer_url"]
+  end
+
+  test "environment-specific settings override shared settings" do
+    config_content = {
+      "shared" => {
+        "authentication" => [ "none" ],
+        "adapter" => "simple",
+        "verbose_logging" => true,
+        "profiles" => {
+          "primary" => {
+            "tools" => [ "all" ],
+            "prompts" => [ "all" ],
+            "resources" => [ "all" ]
+          }
+        }
+      },
+      "test" => {
+        "adapter" => "test",
+        "verbose_logging" => false,
+        "gateway_class" => "CustomGateway"
+      }
+    }
+
+    File.write(@original_config_path, YAML.dump(config_content))
+
+    # Force configuration reload
+    ActionMCP.instance_variable_set(:@configuration, nil)
+    config = ActionMCP.configuration
+    config.load_profiles
+
+    assert_equal "test", config.adapter
+    assert_equal false, config.verbose_logging
+    assert_equal "CustomGateway", config.instance_variable_get(:@gateway_class_name)
+  end
+
+  test "deep symbolize keys works for nested profile configuration" do
+    config_content = {
+      "shared" => {
+        "authentication" => [ "none" ],
+        "profiles" => {
+          "test_profile" => {
+            "tools" => [ "Tool1" ],
+            "prompts" => [ "Prompt1" ],
+            "resources" => [ "Resource1" ],
+            "options" => {
+              "list_changed" => true,
+              "nested_config" => {
+                "deep_key" => "deep_value"
+              }
+            }
+          }
+        }
+      },
+      "test" => {
+        "profile" => "test_profile"
+      }
+    }
+
+    File.write(@original_config_path, YAML.dump(config_content))
+
+    # Force configuration reload
+    ActionMCP.instance_variable_set(:@configuration, nil)
+    config = ActionMCP.configuration
+    config.load_profiles
+
+    # Verify all keys are symbols
+    profile = config.profiles[:test_profile]
+    assert profile[:tools]
+    assert profile[:prompts]
+    assert profile[:resources]
+    assert profile[:options]
+    assert profile[:options][:list_changed]
+    assert profile[:options][:nested_config]
+    assert_equal "deep_value", profile[:options][:nested_config][:deep_key]
+  end
+
+  test "filtered tools respects profile configuration" do
+    config_content = {
+      "shared" => {
+        "authentication" => [ "none" ],
+        "profiles" => {
+          "limited" => {
+            "tools" => [ "AddTool", "SubtractTool" ],
+            "prompts" => [],
+            "resources" => []
+          }
+        }
+      },
+      "test" => {
+        "profile" => "limited"
+      }
+    }
+
+    File.write(@original_config_path, YAML.dump(config_content))
+
+    # Force configuration reload
+    ActionMCP.instance_variable_set(:@configuration, nil)
+    config = ActionMCP.configuration
+    config.load_profiles
+
+    # Create some mock tools for testing
+    add_tool = Class.new(ActionMCP::Tool) do
+      def self.name
+        "AddTool"
+      end
+    end
+
+    subtract_tool = Class.new(ActionMCP::Tool) do
+      def self.name
+        "SubtractTool"
+      end
+    end
+
+    multiply_tool = Class.new(ActionMCP::Tool) do
+      def self.name
+        "MultiplyTool"
+      end
+    end
+
+    # We can't easily test filtered_tools without real tool classes in the registry
+    # So we'll just verify the profile configuration is correct
+    assert_equal [ "AddTool", "SubtractTool" ], config.profiles[:limited][:tools]
+  end
+
+  test "empty profile arrays don't generate capabilities" do
+    config_content = {
+      "shared" => {
+        "authentication" => [ "none" ],
+        "profiles" => {
+          "empty" => {
+            "tools" => [],
+            "prompts" => [],
+            "resources" => []
+          }
+        }
+      },
+      "test" => {
+        "profile" => "empty"
+      }
+    }
+
+    File.write(@original_config_path, YAML.dump(config_content))
+
+    # Force configuration reload
+    ActionMCP.instance_variable_set(:@configuration, nil)
+    config = ActionMCP.configuration
+    config.load_profiles
+    capabilities = config.capabilities
+
+    refute capabilities[:tools], "Empty tools array should not generate capability"
+    refute capabilities[:prompts], "Empty prompts array should not generate capability"
+    refute capabilities[:resources], "Empty resources array should not generate capability"
+  end
+end

--- a/test/integration/mcp_spec_validation_test.rb
+++ b/test/integration/mcp_spec_validation_test.rb
@@ -4,6 +4,9 @@ require "test_helper"
 
 class McpSpecValidationTest < ActionDispatch::IntegrationTest
   setup do
+    # Ensure configuration is properly loaded before creating sessions
+    ActionMCP.configuration.name = "ActionMCP Dummy"
+
     # Create session through the session store
     session_store = ActionMCP::Server.session_store
     @session = session_store.create_session(nil, {

--- a/test/models/action_mcp/session_test.rb
+++ b/test/models/action_mcp/session_test.rb
@@ -38,6 +38,10 @@ require "test_helper"
 
 module ActionMCP
   class SessionTest < ActiveSupport::TestCase
+    setup do
+      # Ensure configuration is properly loaded before creating sessions
+      ActionMCP.configuration.name = "ActionMCP Dummy"
+    end
     test "server capability payload" do
       session = Session.create
 


### PR DESCRIPTION
## Summary
This PR fixes several critical configuration loading issues in ActionMCP:

- **Fixed undefined variable bugs**: Changed `config` to `app_config` in configuration.rb
- **Implemented proper deep_merge**: Profiles now merge instead of replacing, allowing customization while preserving defaults
- **Added configuration name preservation**: App name is now preserved when `load_profiles` is called
- **Fixed Rails config caching**: Integration tests now properly clear Rails configuration cache
- **Fixed test isolation**: Authentication configuration no longer leaks between tests
- **Added comprehensive integration tests**: Real YAML files are now used instead of stubbing

## Test Plan
- [x] All existing tests pass
- [x] New integration tests verify configuration loading from YAML files
- [x] Configuration merging works correctly
- [x] Test isolation is maintained
- [x] Authentication configuration resets properly between tests

## Changes
- `lib/action_mcp/configuration.rb`: Fixed undefined variables and added deep_merge for profiles
- `test/integration/configuration_integration_test.rb`: New comprehensive integration tests
- `test/test_helper.rb`: Fixed authentication test helper to prevent state leakage
- Various test files: Added proper configuration setup for consistent test behavior

All tests now pass consistently with proper configuration loading from mcp.yml files.