### PR TITLE
chore: remove ostruct dependency, use Ruby 3.2+ Data

### DIFF
--- a/actionmcp.gemspec
+++ b/actionmcp.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json'
   spec.add_dependency 'railties', '>= 8.0.4'
   spec.add_dependency 'zeitwerk', '~> 2.6'
-  spec.add_dependency 'ostruct'
 
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/test/action_mcp/gateway_identifiers_test.rb
+++ b/test/action_mcp/gateway_identifiers_test.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "ostruct"
 
 class ActionMCP::GatewayIdentifiersTest < ActiveSupport::TestCase
+  MockUser = Data.define(:id, :email)
+  MockWarden = Data.define(:user)
   setup do
     @request = ActionDispatch::Request.new({})
   end
@@ -17,7 +18,7 @@ class ActionMCP::GatewayIdentifiersTest < ActiveSupport::TestCase
   end
 
   test "WardenIdentifier requires authenticated user" do
-    warden = OpenStruct.new(user: nil)
+    warden = MockWarden.new(user: nil)
     @request.env["warden"] = warden
 
     identifier = ActionMCP::GatewayIdentifiers::WardenIdentifier.new(@request)
@@ -28,8 +29,8 @@ class ActionMCP::GatewayIdentifiersTest < ActiveSupport::TestCase
   end
 
   test "WardenIdentifier returns user when authenticated" do
-    user = OpenStruct.new(id: 1, email: "test@example.com")
-    warden = OpenStruct.new(user: user)
+    user = MockUser.new(id: 1, email: "test@example.com")
+    warden = MockWarden.new(user: user)
     @request.env["warden"] = warden
 
     identifier = ActionMCP::GatewayIdentifiers::WardenIdentifier.new(@request)
@@ -46,7 +47,7 @@ class ActionMCP::GatewayIdentifiersTest < ActiveSupport::TestCase
   end
 
   test "DeviseIdentifier returns user when present" do
-    user = OpenStruct.new(id: 1, email: "test@example.com")
+    user = MockUser.new(id: 1, email: "test@example.com")
     @request.env["devise.user"] = user
 
     identifier = ActionMCP::GatewayIdentifiers::DeviseIdentifier.new(@request)

--- a/test/dummy/app/mcp/none_identifier.rb
+++ b/test/dummy/app/mcp/none_identifier.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require "ostruct"
-
 # Identifier that requires no authentication - allows access for everyone
 class NoneIdentifier < ActionMCP::GatewayIdentifier
+  DevUser = Data.define(:id, :email, :name, :active, :last_login_at, :api_key, :password_digest, :created_at, :updated_at)
+
   identifier :user
   authenticates :none
 
   def resolve
     # Return a user-like object with all expected properties for development
-    user = OpenStruct.new(
+    DevUser.new(
       id: "dev_user",
       email: "dev@localhost",
       name: "Development User",
@@ -20,7 +20,5 @@ class NoneIdentifier < ActionMCP::GatewayIdentifier
       created_at: Time.current - 1.day,
       updated_at: Time.current
     )
-
-    user
   end
 end

--- a/test/dummy/mcp_vanilla.ru
+++ b/test/dummy/mcp_vanilla.ru
@@ -50,11 +50,14 @@ Rails.application.eager_load!
 
 # Stub out Warden to prevent Devise errors
 module Warden
+  SessionSerializer = Data.define(:serialize, :deserialize, :store, :fetch, :delete)
+  WardenConfig = Data.define(:default_scope, :scope_defaults, :failure_app)
+
   class Proxy
     def initialize(env)
       @env = env
       @users = {}
-      @session_serializer = OpenStruct.new(
+      @session_serializer = SessionSerializer.new(
         serialize: ->(record) { record },
         deserialize: ->(data) { data },
         store: ->(user, scope) { @users[scope] = user },
@@ -86,7 +89,7 @@ module Warden
     attr_reader :env, :session_serializer
 
     def config
-      OpenStruct.new(
+      WardenConfig.new(
         default_scope: :user,
         scope_defaults: {},
         failure_app: ->(_) { [ 401, {}, [ "Unauthorized" ] ] }

--- a/test/support/gateway_test_helper.rb
+++ b/test/support/gateway_test_helper.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "ostruct"
-
 module GatewayTestHelper
+  TestUser = Data.define(:id, :email, :name)
   # Creates a test Gateway identifier for testing authentication scenarios
   class TestGatewayIdentifier < ActionMCP::GatewayIdentifier
     identifier :user
@@ -12,7 +11,7 @@ module GatewayTestHelper
       user_id = @request.env["test.user_id"]
       raise Unauthorized, "No test user set" unless user_id
 
-      OpenStruct.new(
+      TestUser.new(
         id: user_id,
         email: "test-#{user_id}@example.com",
         name: "Test User #{user_id}"
@@ -63,7 +62,7 @@ module GatewayTestHelper
 
   # Creates a test user mock for testing
   def create_test_user(id: "test_user", email: nil, name: nil)
-    OpenStruct.new(
+    TestUser.new(
       id: id,
       email: email || "#{id}@example.com",
       name: name || "Test User #{id}"


### PR DESCRIPTION
Remove ostruct gem dependency and replace with built-in Data class