### PR TITLE
fix: tool/prompt re-registration when explicit name is set

### DIFF
--- a/lib/action_mcp/capability.rb
+++ b/lib/action_mcp/capability.rb
@@ -11,6 +11,7 @@ module ActionMCP
     include Renderable
 
     class_attribute :_capability_name, instance_accessor: false
+    class_attribute :_registered_name, instance_accessor: false
     class_attribute :_description, instance_accessor: false, default: ""
 
     attr_reader :execution_context

--- a/lib/action_mcp/prompt.rb
+++ b/lib/action_mcp/prompt.rb
@@ -18,10 +18,26 @@ module ActionMCP
     def self.prompt_name(name = nil)
       if name
         self._capability_name = name
+        re_register_if_needed
+        name
       else
         _capability_name || default_prompt_name
       end
     end
+
+    # Re-registers the prompt if it was already registered under a different name
+    # @return [void]
+    def self.re_register_if_needed
+      return if abstract?
+      return unless _registered_name # Not yet registered
+
+      new_name = capability_name
+      return if _registered_name == new_name # No change
+
+      ActionMCP::PromptsRegistry.re_register(self, _registered_name)
+    end
+
+    private_class_method :re_register_if_needed
 
     # Returns the default prompt name based on the class name.
     #

--- a/lib/action_mcp/registry_base.rb
+++ b/lib/action_mcp/registry_base.rb
@@ -21,7 +21,29 @@ module ActionMCP
       def register(klass)
         return if klass.abstract?
 
-        items[klass.capability_name] = klass
+        name = klass.capability_name
+        items[name] = klass
+        klass._registered_name = name if klass.respond_to?(:_registered_name=)
+      end
+
+      # Re-register an item under its current capability_name
+      # Removes old entry if name changed
+      #
+      # @param klass [Class] The class to re-register
+      # @param old_name [String] The previous registered name
+      # @return [void]
+      def re_register(klass, old_name)
+        return if klass.abstract?
+
+        new_name = klass.capability_name
+
+        # Remove old entry if it exists and points to this class
+        if old_name && items[old_name] == klass
+          items.delete(old_name)
+        end
+
+        items[new_name] = klass
+        klass._registered_name = new_name if klass.respond_to?(:_registered_name=)
       end
 
       # Unregister an item

--- a/lib/action_mcp/tool.rb
+++ b/lib/action_mcp/tool.rb
@@ -40,10 +40,26 @@ module ActionMCP
     def self.tool_name(name = nil)
       if name
         self._capability_name = name
+        re_register_if_needed
+        name
       else
         _capability_name || default_tool_name
       end
     end
+
+    # Re-registers the tool if it was already registered under a different name
+    # @return [void]
+    def self.re_register_if_needed
+      return if abstract?
+      return unless _registered_name # Not yet registered
+
+      new_name = capability_name
+      return if _registered_name == new_name # No change
+
+      ActionMCP::ToolsRegistry.re_register(self, _registered_name)
+    end
+
+    private_class_method :re_register_if_needed
 
     # Returns a default tool name based on the class name.
     #

--- a/test/action_mcp/prompt_reregistration_test.rb
+++ b/test/action_mcp/prompt_reregistration_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionMCP
+  class PromptReregistrationTest < ActiveSupport::TestCase
+    setup do
+      @original_prompts = PromptsRegistry.items.dup
+      PromptsRegistry.clear!
+    end
+
+    teardown do
+      PromptsRegistry.clear!
+      @original_prompts.each do |name, klass|
+        PromptsRegistry.items[name] = klass
+      end
+    end
+
+    test "_registered_name is set after registration" do
+      PromptsRegistry.register(Cat::GreetingPrompt)
+
+      assert_equal "cat__greeting", Cat::GreetingPrompt._registered_name
+    end
+
+    test "re_register removes old entry and adds new entry" do
+      # Create a test prompt class with explicit name
+      test_prompt = Class.new(ActionMCP::Prompt) do
+        prompt_name "test_reregister_prompt"
+        description "Test prompt"
+
+        def perform
+          render text: "Hello"
+        end
+      end
+
+      # Manually register under wrong name to simulate timing issue
+      PromptsRegistry.items["wrong_prompt_name"] = test_prompt
+      test_prompt._registered_name = "wrong_prompt_name"
+
+      # Now call re_register
+      PromptsRegistry.re_register(test_prompt, "wrong_prompt_name")
+
+      # Old entry should be gone
+      refute_includes PromptsRegistry.prompts.keys, "wrong_prompt_name"
+      # New entry should exist
+      assert_includes PromptsRegistry.prompts.keys, "test_reregister_prompt"
+      assert_equal "test_reregister_prompt", test_prompt._registered_name
+    end
+
+    test "re-registration is idempotent" do
+      PromptsRegistry.register(Cat::GreetingPrompt)
+      initial_size = PromptsRegistry.prompts.size
+
+      # Calling prompt_name again with same value should not duplicate
+      Cat::GreetingPrompt.prompt_name("cat__greeting")
+
+      assert_equal initial_size, PromptsRegistry.prompts.size
+    end
+
+    test "abstract prompts are not re-registered" do
+      initial_size = PromptsRegistry.prompts.size
+
+      PromptsRegistry.re_register(ApplicationMCPPrompt, "some_name")
+
+      assert_equal initial_size, PromptsRegistry.prompts.size
+    end
+  end
+end

--- a/test/action_mcp/tool_reregistration_test.rb
+++ b/test/action_mcp/tool_reregistration_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionMCP
+  class ToolReregistrationTest < ActiveSupport::TestCase
+    setup do
+      @original_tools = ToolsRegistry.items.dup
+      ToolsRegistry.clear!
+    end
+
+    teardown do
+      ToolsRegistry.clear!
+      @original_tools.each do |name, klass|
+        ToolsRegistry.items[name] = klass
+      end
+    end
+
+    test "tool with explicit tool_name registers under custom name not default" do
+      ToolsRegistry.register(Spaceship::WeatherTool)
+
+      # Should be registered under explicit name
+      assert_includes ToolsRegistry.tools.keys, "spaceship_weather"
+      # Should NOT be registered under default name
+      refute_includes ToolsRegistry.tools.keys, "spaceship__weather"
+    end
+
+    test "tool without explicit tool_name uses default name" do
+      ToolsRegistry.register(Mars::WeatherTool)
+
+      assert_includes ToolsRegistry.tools.keys, "mars__weather"
+    end
+
+    test "re-registration is idempotent" do
+      ToolsRegistry.register(Spaceship::WeatherTool)
+      initial_size = ToolsRegistry.tools.size
+
+      # Calling tool_name again with same value should not duplicate
+      Spaceship::WeatherTool.tool_name("spaceship_weather")
+
+      assert_equal initial_size, ToolsRegistry.tools.size
+      assert_equal 1, ToolsRegistry.tools.values.count { |k| k == Spaceship::WeatherTool }
+    end
+
+    test "_registered_name is set after registration" do
+      ToolsRegistry.register(Spaceship::WeatherTool)
+
+      assert_equal "spaceship_weather", Spaceship::WeatherTool._registered_name
+    end
+
+    test "re_register removes old entry and adds new entry" do
+      # Manually register under a wrong name to simulate the timing issue
+      ToolsRegistry.items["wrong_name"] = Spaceship::WeatherTool
+      Spaceship::WeatherTool._registered_name = "wrong_name"
+
+      # Now call re_register
+      ToolsRegistry.re_register(Spaceship::WeatherTool, "wrong_name")
+
+      # Old entry should be gone
+      refute_includes ToolsRegistry.tools.keys, "wrong_name"
+      # New entry should exist
+      assert_includes ToolsRegistry.tools.keys, "spaceship_weather"
+      assert_equal "spaceship_weather", Spaceship::WeatherTool._registered_name
+    end
+
+    test "abstract tools are not re-registered" do
+      # ApplicationMCPTool is abstract
+      initial_size = ToolsRegistry.tools.size
+
+      ToolsRegistry.re_register(ApplicationMCPTool, "some_name")
+
+      assert_equal initial_size, ToolsRegistry.tools.size
+    end
+  end
+end

--- a/test/all_tools_and_prompts_test.rb
+++ b/test/all_tools_and_prompts_test.rb
@@ -33,16 +33,17 @@ class AllToolsAndPromptsTest < ActiveSupport::TestCase
   end
 
   test "FormatCodeTool is findable" do
-    assert_tool_findable("format_code")
+    # FormatCodeTool has explicit tool_name "format_source_legacy"
+    assert_tool_findable("format_source_legacy")
   end
 
   test "GitHubCreateIssueTool is findable" do
-    # Test registry key (internal)
-    assert_tool_findable("git_hub_create_issue")
+    # Test registry key (internal) - GitHubCreateIssueTool has tool_name "create_github_issue"
+    assert_tool_findable("create_github_issue")
 
     # Test custom tool_name (MCP protocol) via session
     session = ActionMCP::Session.new(protocol_version: "2025-06-18")
-    session.tool_registry = [ "git_hub_create_issue" ] # Register by registry key
+    session.tool_registry = [ "create_github_issue" ] # Register by registry key
     registered_tools = session.registered_tools
 
     # Find tool by its MCP protocol name


### PR DESCRIPTION
The inherited hook fires before class bodies are parsed, so explicit tool_name/prompt_name DSL calls were ignored during initial registration.

Now tracks _registered_name and re-registers when the name changes.

Closes #152

@AaronCDee   handled the case when tool are not registered in dev env.

Production never had this problem since the eager_loading was triggered.