### PR TITLE
feat: add structured content validation against output_schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem "database_cleaner-active_record", group: :test
 gem "minitest-reporters", group: :test
 gem "maxitest", group: :test
 
+# Optional: Schema validation for structured content
+gem "json_schemer", ">= 2.4", group: [ :development, :test ]
+
 # File system watching for development
 gem "listen", group: :development
 

--- a/TOOLS.MD
+++ b/TOOLS.MD
@@ -360,6 +360,50 @@ end
 
 **Key benefit:** LLMs can reliably extract specific data from your tool's response instead of parsing free-form text.
 
+### Schema-Data Alignment (MCP Compliance)
+
+Per MCP specification, servers **MUST** provide structured results that conform to the declared `output_schema`. Your data structure must exactly match your schema declaration.
+
+**Named objects in arrays create wrappers:**
+
+```ruby
+output_schema do
+  array :items do
+    object :entry do        # Named object = items have "entry" wrapper
+      property :name, type: "string"
+      property :value, type: "number"
+    end
+  end
+end
+
+def perform
+  # Data MUST include the "entry" wrapper to match schema
+  render structured: {
+    items: [
+      { entry: { name: "foo", value: 42 } }
+    ]
+  }
+end
+```
+
+**Enable validation to catch mismatches:**
+
+ActionMCP can validate structured content against your schema. Add `json_schemer` to your Gemfile:
+
+```ruby
+# Gemfile
+gem 'json_schemer', '~> 2.4'
+```
+
+Then enable validation:
+
+```ruby
+# config/environments/development.rb
+config.action_mcp.validate_structured_content = true
+```
+
+When enabled, `render structured:` will raise `ActionMCP::StructuredContentValidationError` if data doesn't match schema.
+
 ### Input vs Output Schema Differences
 
 **Important distinction:**

--- a/actionmcp.gemspec
+++ b/actionmcp.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   # Development dependencies
-  spec.add_development_dependency 'json_schemer', '~> 2.0'
+  spec.add_development_dependency 'json_schemer', '>= 2.4'
 end

--- a/lib/action_mcp.rb
+++ b/lib/action_mcp.rb
@@ -31,6 +31,9 @@ module ActionMCP
   require_relative "action_mcp/version"
   require_relative "action_mcp/client"
 
+  # Error raised when structured content doesn't match the declared output_schema
+  class StructuredContentValidationError < StandardError; end
+
   # Protocol version constants
   SUPPORTED_VERSIONS = [
     "2025-11-25", # The Task Master - Tasks, icons, tool naming, polling SSE

--- a/lib/action_mcp/configuration.rb
+++ b/lib/action_mcp/configuration.rb
@@ -47,7 +47,9 @@ module ActionMCP
                   # --- Tasks Options (MCP 2025-11-25) ---
                   :tasks_enabled,
                   :tasks_list_enabled,
-                  :tasks_cancel_enabled
+                  :tasks_cancel_enabled,
+                  # --- Schema Validation Options ---
+                  :validate_structured_content
 
     def initialize
       @logging_enabled = false
@@ -68,6 +70,9 @@ module ActionMCP
       @tasks_enabled = false
       @tasks_list_enabled = true
       @tasks_cancel_enabled = true
+
+      # Schema validation - disabled by default for backward compatibility
+      @validate_structured_content = false
 
       # Gateway - resolved lazily to account for Zeitwerk autoloading
       @gateway_class_name = nil

--- a/lib/action_mcp/output_schema_builder.rb
+++ b/lib/action_mcp/output_schema_builder.rb
@@ -127,12 +127,12 @@ module ActionMCP
     end
 
     # Define an object property
-    # @param name [Symbol] Object property name
+    # @param name [Symbol, nil] Object property name. If nil, returns schema directly (for array items)
     # @param required [Boolean] Whether the object is required
     # @param description [String] Property description
     # @param additional_properties [Boolean, Hash] Whether to allow additional properties
     # @param block [Proc] Block defining object properties
-    def object(name, required: false, description: nil, additional_properties: nil, &block)
+    def object(name = nil, required: false, description: nil, additional_properties: nil, &block)
       raise ArgumentError, "Object definition requires a block" unless block_given?
 
       # Create nested builder for object properties
@@ -149,10 +149,14 @@ module ActionMCP
       # Add additionalProperties if specified
       add_additional_properties_to_schema(schema, additional_properties)
 
-      @properties[name.to_s] = schema
-      @required << name.to_s if required
-
-      name.to_s
+      if name
+        @properties[name.to_s] = schema
+        @required << name.to_s if required
+        name.to_s
+      else
+        # Return schema directly for use in array items
+        schema
+      end
     end
 
     # Set additionalProperties for the root schema

--- a/test/dummy/app/mcp/tools/weather_tool.rb
+++ b/test/dummy/app/mcp/tools/weather_tool.rb
@@ -70,23 +70,27 @@ class WeatherTool < ApplicationMCPTool
     }
 
     # Add forecast if requested
+    # Data structure must match schema: `object :day do` requires `day:` wrapper
     if include_forecast
       weather_data[:forecast] = [
         {
-          date: Date.current.to_s,
-          high: units == "fahrenheit" ? 75 : 24,
-          low: units == "fahrenheit" ? 68 : 20,
-          condition: "Sunny",
-          precipitation: 0
+          day: {
+            date: Date.current.to_s,
+            high: units == "fahrenheit" ? 75 : 24,
+            low: units == "fahrenheit" ? 68 : 20,
+            condition: "Sunny",
+            precipitation: 0
+          }
         },
         {
-          date: (Date.current + 1).to_s,
-          high: units == "fahrenheit" ? 73 : 23,
-          low: units == "fahrenheit" ? 66 : 19,
-          condition: "Light rain",
-          precipitation: 2.5
+          day: {
+            date: (Date.current + 1).to_s,
+            high: units == "fahrenheit" ? 73 : 23,
+            low: units == "fahrenheit" ? 66 : 19,
+            condition: "Light rain",
+            precipitation: 2.5
+          }
         }
-        # ... more forecast days
       ]
 
       render text: "Including 5-day forecast"

--- a/test/structured_content_validation_test.rb
+++ b/test/structured_content_validation_test.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class StructuredContentValidationTest < ActiveSupport::TestCase
+  setup do
+    @original_setting = ActionMCP.configuration.validate_structured_content
+  end
+
+  teardown do
+    ActionMCP.configuration.validate_structured_content = @original_setting
+  end
+
+  test "validation is disabled by default" do
+    assert_equal false, ActionMCP.configuration.validate_structured_content
+  end
+
+  test "validation can be enabled via configuration" do
+    ActionMCP.configuration.validate_structured_content = true
+    assert_equal true, ActionMCP.configuration.validate_structured_content
+  end
+
+  test "weather tool with forecast passes validation when data matches schema" do
+    ActionMCP.configuration.validate_structured_content = true
+
+    tool = WeatherTool.new(location: "NYC", units: "celsius", include_forecast: true)
+    result = tool.call
+
+    assert_not result.is_error, "Tool should not return error"
+    assert result.structured_content.present?, "Should have structured content"
+    assert result.structured_content[:forecast].present?, "Should have forecast"
+
+    # Verify data structure matches schema (has day wrapper)
+    first_forecast = result.structured_content[:forecast].first
+    assert first_forecast.key?(:day), "Forecast item should have :day wrapper"
+    assert first_forecast[:day].key?(:date), "Day should have :date"
+  end
+
+  test "validation is skipped when disabled" do
+    ActionMCP.configuration.validate_structured_content = false
+
+    # Create a tool with mismatched data/schema - should NOT raise
+    tool = WeatherTool.new(location: "NYC", units: "celsius")
+    result = tool.call
+
+    assert_not result.is_error
+  end
+
+  test "validation returns error response when data does not match schema" do
+    ActionMCP.configuration.validate_structured_content = true
+
+    # Create a tool class with intentionally mismatched data
+    tool_class = Class.new(ApplicationMCPTool) do
+      tool_name "mismatched_tool"
+      description "Tool with mismatched data"
+
+      output_schema do
+        property :name, type: "string", required: true
+        property :count, type: "number", required: true
+      end
+
+      def perform
+        # Missing required "count" field
+        render structured: { name: "test" }
+      end
+    end
+
+    tool = tool_class.new
+    result = tool.call
+
+    # Tool catches exceptions and returns error response
+    assert result.is_error, "Should be an error response"
+    assert_nil result.structured_content, "Should not have structured content on error"
+  end
+
+  test "validation passes when all required fields present" do
+    ActionMCP.configuration.validate_structured_content = true
+
+    tool_class = Class.new(ApplicationMCPTool) do
+      tool_name "valid_tool"
+      description "Tool with valid data"
+
+      output_schema do
+        property :name, type: "string", required: true
+        property :count, type: "number", required: true
+      end
+
+      def perform
+        render structured: { name: "test", count: 42 }
+      end
+    end
+
+    tool = tool_class.new
+    result = tool.call
+
+    assert_not result.is_error
+    assert_equal "test", result.structured_content[:name]
+    assert_equal 42, result.structured_content[:count]
+  end
+
+  test "object in array generates correct schema structure" do
+    builder = ActionMCP::OutputSchemaBuilder.new
+    builder.instance_eval do
+      array :items do
+        object :entry do
+          property :name, type: "string"
+          property :value, type: "number"
+        end
+      end
+    end
+
+    schema = builder.to_json_schema
+    items_schema = schema.dig("properties", "items", "items")
+
+    # Named object creates wrapper
+    assert_equal "object", items_schema["type"]
+    assert items_schema["properties"].key?("entry"), "Should have 'entry' property"
+    assert_equal "object", items_schema["properties"]["entry"]["type"]
+    assert items_schema["properties"]["entry"]["properties"].key?("name")
+  end
+
+  test "anonymous object in array generates flat item structure" do
+    builder = ActionMCP::OutputSchemaBuilder.new
+    builder.instance_eval do
+      array :items do
+        object do
+          property :name, type: "string"
+          property :value, type: "number"
+        end
+      end
+    end
+
+    schema = builder.to_json_schema
+    items_schema = schema.dig("properties", "items", "items")
+
+    # Anonymous object = items ARE the objects directly
+    assert_equal "object", items_schema["type"]
+    assert items_schema["properties"].key?("name"), "Should have 'name' property directly"
+    assert items_schema["properties"].key?("value"), "Should have 'value' property directly"
+    assert_not items_schema["properties"].key?("object"), "Should NOT have 'object' wrapper"
+  end
+end


### PR DESCRIPTION
The DSL allowed generating schemas that are not spec compliant.

Frontier models understand them if feed directly, strict clients don't accept them.