### PR TITLE
fix: embedded resource format per MCP spec

### DIFF
--- a/lib/action_mcp/content/resource.rb
+++ b/lib/action_mcp/content/resource.rb
@@ -28,13 +28,16 @@ module ActionMCP
       end
 
       # Returns a hash representation of the resource content.
+      # Per MCP spec, embedded resources have type "resource" with a nested resource object.
       #
       # @return [Hash] The hash representation of the resource content.
       def to_h
-        resource_data = super.merge(uri: @uri, mimeType: @mime_type)
-        resource_data[:text] = @text if @text
-        resource_data[:blob] = @blob if @blob
-        resource_data
+        inner = { uri: @uri, mimeType: @mime_type }
+        inner[:text] = @text if @text
+        inner[:blob] = @blob if @blob
+        inner[:annotations] = @annotations if @annotations
+
+        { type: @type, resource: inner }
       end
     end
   end

--- a/test/action_mcp/content/resource_test.rb
+++ b/test/action_mcp/content/resource_test.rb
@@ -50,14 +50,14 @@ module ActionMCP
 
       test "#to_h returns correct hash with uri and mime_type" do
         resource = Resource.new("gemfile://test", "text/plain", annotations: nil)
-        expected = { type: "resource", uri: "gemfile://test", mimeType: "text/plain" }
+        expected = { type: "resource", resource: { uri: "gemfile://test", mimeType: "text/plain" } }
 
         assert_equal expected, resource.to_h
       end
 
       test "#to_h includes text when present" do
         resource = Resource.new("gemfile://test", "text/plain", text: "sample text", annotations: nil)
-        expected = { type: "resource", uri: "gemfile://test", mimeType: "text/plain", text: "sample text" }
+        expected = { type: "resource", resource: { uri: "gemfile://test", mimeType: "text/plain", text: "sample text" } }
 
         assert_equal expected, resource.to_h
       end
@@ -65,7 +65,7 @@ module ActionMCP
       test "#to_h includes blob when present" do
         blob = Base64.strict_encode64("sample blob")
         resource = Resource.new("gemfile://test", "application/octet-stream", blob: blob, annotations: nil)
-        expected = { type: "resource", uri: "gemfile://test", mimeType: "application/octet-stream", blob: blob }
+        expected = { type: "resource", resource: { uri: "gemfile://test", mimeType: "application/octet-stream", blob: blob } }
 
         assert_equal expected, resource.to_h
       end
@@ -82,9 +82,11 @@ module ActionMCP
 
         expected = {
           type: "resource",
-          uri: "gemfile://test",
-          mimeType: "application/json",
-          text: gemfile_json
+          resource: {
+            uri: "gemfile://test",
+            mimeType: "application/json",
+            text: gemfile_json
+          }
         }
 
         assert_equal expected, resource.to_h

--- a/test/action_mcp/content_test.rb
+++ b/test/action_mcp/content_test.rb
@@ -61,24 +61,24 @@ module ActionMCP
 
         # Without optional text or blob
         resource = Resource.new(uri, mime_type)
-        expected = { type: "resource", uri: uri, mimeType: mime_type }
+        expected = { type: "resource", resource: { uri: uri, mimeType: mime_type } }
         assert_equal expected, resource.to_h
 
         # With text only
         text_content = "Optional text"
         resource_with_text = Resource.new(uri, mime_type, text: text_content)
-        expected_with_text = { type: "resource", uri: uri, mimeType: mime_type, text: text_content }
+        expected_with_text = { type: "resource", resource: { uri: uri, mimeType: mime_type, text: text_content } }
         assert_equal expected_with_text, resource_with_text.to_h
 
         # With blob only
         blob_content = "base64encodedblob"
         resource_with_blob = Resource.new(uri, mime_type, blob: blob_content)
-        expected_with_blob = { type: "resource", uri: uri, mimeType: mime_type, blob: blob_content }
+        expected_with_blob = { type: "resource", resource: { uri: uri, mimeType: mime_type, blob: blob_content } }
         assert_equal expected_with_blob, resource_with_blob.to_h
 
         # With both text and blob
         resource_full = Resource.new(uri, mime_type, text: text_content, blob: blob_content)
-        expected_full = { type: "resource", uri: uri, mimeType: mime_type, text: text_content, blob: blob_content }
+        expected_full = { type: "resource", resource: { uri: uri, mimeType: mime_type, text: text_content, blob: blob_content } }
         assert_equal expected_full, resource_full.to_h
       end
 
@@ -87,7 +87,7 @@ module ActionMCP
         mime_type = "application/pdf"
         annotations = { "audience" => [ "user" ], "priority" => 1 }
         resource = Resource.new(uri, mime_type, annotations: annotations)
-        expected = { type: "resource", uri: uri, mimeType: mime_type, annotations: annotations }
+        expected = { type: "resource", resource: { uri: uri, mimeType: mime_type, annotations: annotations } }
         assert_equal annotations, resource.annotations
         assert_equal expected, resource.to_h
       end


### PR DESCRIPTION
## Summary
- Fixed embedded resource `to_h` format to match MCP spec
- `type: "resource"` now wraps content in nested `resource` object

Release-As: 0.102.0