### PR TITLE
feat: Add filter_tools_list and custom_method_handler extension hooks

### DIFF
--- a/lib/action_mcp/server/handlers/custom_method_routing.rb
+++ b/lib/action_mcp/server/handlers/custom_method_routing.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ActionMCP
+  module Server
+    module Handlers
+      module CustomMethodRouting
+        private
+
+        def route_custom_method_or_raise(rpc_method, id, params, transport)
+          handler = ActionMCP.configuration.custom_method_handler
+          return if handler&.call(rpc_method, id, params, transport)
+
+          raise JSON_RPC::JsonRpcError.new(:method_not_found, message: "Method not found: #{rpc_method}")
+        rescue JSON_RPC::JsonRpcError
+          raise
+        rescue StandardError => e
+          Rails.logger.error "custom_method_handler error: #{e.class} - #{e.message}"
+          raise JSON_RPC::JsonRpcError.new(:internal_error, message: "Custom method handler error")
+        end
+      end
+    end
+  end
+end

--- a/lib/action_mcp/server/handlers/router.rb
+++ b/lib/action_mcp/server/handlers/router.rb
@@ -4,6 +4,8 @@ module ActionMCP
   module Server
     module Handlers
       class Router
+        include CustomMethodRouting
+
         def initialize(handler)
           @handler = handler
         end
@@ -23,8 +25,7 @@ module ActionMCP
           when "completion/complete"
             @handler.process_completion_complete(id, params)
           else
-            raise ActionMCP::Server::JSON_RPC::JsonRpcError.new(:method_not_found,
-                                                                message: "Method not found: #{rpc_method}")
+            route_custom_method_or_raise(rpc_method, id, params, @handler.transport)
           end
         end
       end

--- a/lib/action_mcp/server/json_rpc_handler.rb
+++ b/lib/action_mcp/server/json_rpc_handler.rb
@@ -8,6 +8,7 @@ module ActionMCP
       include Handlers::PromptHandler
       include Handlers::LoggingHandler
       include Handlers::TaskHandler
+      include Handlers::CustomMethodRouting
       include ErrorHandling
       include ErrorAware
 
@@ -62,7 +63,7 @@ module ActionMCP
         when Methods::LOGGING_SET_LEVEL
           handle_logging_set_level(id, params)
         else
-          raise JSON_RPC::JsonRpcError.new(:method_not_found, message: "Method not found: #{rpc_method}")
+          route_custom_method_or_raise(rpc_method, id, params, transport)
         end
       end
 

--- a/test/action_mcp/custom_method_handler_router_test.rb
+++ b/test/action_mcp/custom_method_handler_router_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CustomMethodHandlerRouterTest < ActiveSupport::TestCase
+  setup do
+    session_store = ActionMCP::Server.session_store
+    @session = session_store.create_session(nil, {
+      initialized: false,
+      protocol_version: ActionMCP::DEFAULT_PROTOCOL_VERSION
+    })
+    session_store.save_session(@session)
+    @transport = ActionMCP::Server::TransportHandler.new(@session, messaging_mode: :return)
+    @handler = ActionMCP::Server::JsonRpcHandler.new(@transport)
+    @router = ActionMCP::Server::Handlers::Router.new(@handler)
+  end
+
+  teardown do
+    ActionMCP.configuration.custom_method_handler = nil
+  end
+
+  test "raises method_not_found for unknown method when no handler configured" do
+    error = assert_raises(JSON_RPC::JsonRpcError) do
+      @router.route("vendor/custom", "r-1", {})
+    end
+    assert_includes error.message, "Method not found"
+  end
+
+  test "raises method_not_found when handler returns falsy" do
+    ActionMCP.configuration.custom_method_handler = ->(_m, _id, _p, _t) { nil }
+
+    assert_raises(JSON_RPC::JsonRpcError) do
+      @router.route("vendor/custom", "r-2", {})
+    end
+  end
+
+  test "handles method when handler returns truthy" do
+    ActionMCP.configuration.custom_method_handler = ->(_m, id, _p, transport) {
+      transport.send_jsonrpc_response(id, result: { routed: true })
+      true
+    }
+
+    @router.route("vendor/custom", "r-3", {})
+    response = @transport.get_last_response
+
+    assert_equal({ routed: true }, response.result)
+  end
+
+  test "handler receives correct arguments via router" do
+    received = {}
+    ActionMCP.configuration.custom_method_handler = ->(method, id, params, transport) {
+      received[:method] = method
+      received[:id] = id
+      received[:params] = params
+      received[:transport] = transport
+      true
+    }
+
+    @router.route("sparrow/test", "r-4", { "key" => "val" })
+
+    assert_equal "sparrow/test", received[:method]
+    assert_equal "r-4", received[:id]
+    assert_equal({ "key" => "val" }, received[:params])
+    assert_equal @transport, received[:transport]
+  end
+
+  test "wraps handler exception as internal_error" do
+    ActionMCP.configuration.custom_method_handler = ->(_m, _id, _p, _t) {
+      raise StandardError, "handler blew up"
+    }
+
+    error = assert_raises(JSON_RPC::JsonRpcError) do
+      @router.route("vendor/custom", "r-5", {})
+    end
+    assert_includes error.message, "Custom method handler error"
+  end
+
+  test "passes through JsonRpcError raised by handler" do
+    ActionMCP.configuration.custom_method_handler = ->(_m, _id, _p, _t) {
+      raise JSON_RPC::JsonRpcError.new(:invalid_params, message: "bad params from handler")
+    }
+
+    error = assert_raises(JSON_RPC::JsonRpcError) do
+      @router.route("vendor/custom", "r-6", {})
+    end
+    assert_includes error.message, "bad params from handler"
+  end
+end

--- a/test/action_mcp/filter_tools_list_test.rb
+++ b/test/action_mcp/filter_tools_list_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FilterToolsListTest < ActiveSupport::TestCase
+  setup do
+    session_store = ActionMCP::Server.session_store
+    @session = session_store.create_session(nil, {
+      initialized: false,
+      protocol_version: ActionMCP::DEFAULT_PROTOCOL_VERSION
+    })
+    @session.tool_registry = [ "calculate_sum" ]
+    session_store.save_session(@session)
+    @transport = ActionMCP::Server::TransportHandler.new(@session, messaging_mode: :return)
+  end
+
+  test "returns all tools when session does not respond to filter_tools_list" do
+    refute @session.respond_to?(:filter_tools_list)
+
+    @transport.send_tools_list("test-1")
+    response = @transport.get_last_response
+
+    assert_equal 1, response.result[:tools].length
+  end
+
+  test "calls filter_tools_list when session responds to it" do
+    filter_called = false
+    @session.define_singleton_method(:filter_tools_list) do |tools, _params|
+      filter_called = true
+      tools
+    end
+
+    @transport.send_tools_list("test-2")
+
+    assert filter_called
+  end
+
+  test "uses filter return value as the tools list" do
+    @session.define_singleton_method(:filter_tools_list) do |_tools, _params|
+      []
+    end
+
+    @transport.send_tools_list("test-3")
+    response = @transport.get_last_response
+
+    assert_equal [], response.result[:tools]
+  end
+
+  test "passes registered tools and params to filter" do
+    received_tools = nil
+    received_params = nil
+
+    @session.define_singleton_method(:filter_tools_list) do |tools, params|
+      received_tools = tools
+      received_params = params
+      tools
+    end
+
+    test_params = { "cursor" => "abc" }
+    @transport.send_tools_list("test-4", test_params)
+
+    assert_kind_of Array, received_tools
+    assert_equal 1, received_tools.length
+    assert_equal test_params, received_params
+  end
+
+  test "falls back to unfiltered tools when filter raises" do
+    @session.define_singleton_method(:filter_tools_list) do |_tools, _params|
+      raise StandardError, "filter exploded"
+    end
+
+    @transport.send_tools_list("test-5")
+    response = @transport.get_last_response
+
+    assert_equal 1, response.result[:tools].length
+  end
+
+  test "falls back to unfiltered tools when filter returns nil" do
+    @session.define_singleton_method(:filter_tools_list) do |_tools, _params|
+      nil
+    end
+
+    @transport.send_tools_list("test-6")
+    response = @transport.get_last_response
+
+    assert_equal 1, response.result[:tools].length
+  end
+
+  test "falls back to unfiltered tools when filter returns non-array" do
+    @session.define_singleton_method(:filter_tools_list) do |_tools, _params|
+      "not an array"
+    end
+
+    @transport.send_tools_list("test-7")
+    response = @transport.get_last_response
+
+    assert_equal 1, response.result[:tools].length
+  end
+
+  test "strips nil entries from filtered array" do
+    @session.define_singleton_method(:filter_tools_list) do |tools, _params|
+      [ nil ] + tools
+    end
+
+    @transport.send_tools_list("test-8")
+    response = @transport.get_last_response
+
+    assert_equal 1, response.result[:tools].length
+  end
+
+  test "strips non-tool entries from filtered array" do
+    @session.define_singleton_method(:filter_tools_list) do |tools, _params|
+      [ "CalculateSum", 42 ] + tools
+    end
+
+    @transport.send_tools_list("test-9")
+    response = @transport.get_last_response
+
+    assert_equal 1, response.result[:tools].length
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -234,4 +234,26 @@ class ConfigurationTest < ActiveSupport::TestCase
 
     assert_equal "/mcp", @config.base_path
   end
+
+  test "custom_method_handler defaults to nil" do
+    assert_nil @config.custom_method_handler
+  end
+
+  test "custom_method_handler can be set to a callable" do
+    handler = ->(_method, _id, _params, _transport) { true }
+    @config.custom_method_handler = handler
+    assert_equal handler, @config.custom_method_handler
+  end
+
+  test "custom_method_handler can be cleared with nil" do
+    @config.custom_method_handler = ->(_m, _id, _p, _t) { true }
+    @config.custom_method_handler = nil
+    assert_nil @config.custom_method_handler
+  end
+
+  test "custom_method_handler rejects non-callable values" do
+    assert_raises(ArgumentError) { @config.custom_method_handler = "not callable" }
+    assert_raises(ArgumentError) { @config.custom_method_handler = 42 }
+    assert_raises(ArgumentError) { @config.custom_method_handler = Object.new }
+  end
 end

--- a/test/integration/custom_method_handler_test.rb
+++ b/test/integration/custom_method_handler_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CustomMethodHandlerTest < ActionDispatch::IntegrationTest
+  setup do
+    session_store = ActionMCP::Server.session_store
+    @session = session_store.create_session(nil, {
+      initialized: false,
+      protocol_version: ActionMCP::DEFAULT_PROTOCOL_VERSION
+    })
+    @session_id = @session.id
+    session_store.save_session(@session)
+  end
+
+  teardown do
+    ActionMCP.configuration.custom_method_handler = nil
+  end
+
+  test "unknown method returns method_not_found when no handler configured" do
+    post "/", params: {
+      jsonrpc: "2.0", id: "test-1",
+      method: "vendor/custom/method",
+      params: {}
+    }.to_json, headers: json_headers
+
+    assert_response :success
+    body = response.parsed_body
+    assert body["error"]
+    assert_equal(-32_601, body["error"]["code"])
+    assert_includes body["error"]["message"], "Method not found"
+  end
+
+  test "unknown method returns method_not_found when handler returns falsy" do
+    ActionMCP.configuration.custom_method_handler = ->(_method, _id, _params, _transport) { false }
+
+    post "/", params: {
+      jsonrpc: "2.0", id: "test-2",
+      method: "vendor/custom/method",
+      params: {}
+    }.to_json, headers: json_headers
+
+    assert_response :success
+    body = response.parsed_body
+    assert body["error"]
+    assert_equal(-32_601, body["error"]["code"])
+  end
+
+  test "custom handler handles unknown method when returning truthy" do
+    ActionMCP.configuration.custom_method_handler = ->(_method, id, _params, transport) {
+      transport.send_jsonrpc_response(id, result: { handled: true })
+      true
+    }
+
+    post "/", params: {
+      jsonrpc: "2.0", id: "test-3",
+      method: "vendor/custom/method",
+      params: { key: "value" }
+    }.to_json, headers: json_headers
+
+    assert_response :success
+    body = response.parsed_body
+    assert body["result"]
+    assert_equal true, body["result"]["handled"]
+  end
+
+  test "custom handler receives correct arguments" do
+    received_args = {}
+    ActionMCP.configuration.custom_method_handler = ->(rpc_method, id, params, transport) {
+      received_args[:rpc_method] = rpc_method
+      received_args[:id] = id
+      received_args[:params] = params
+      received_args[:transport_class] = transport.class.name
+      transport.send_jsonrpc_response(id, result: {})
+      true
+    }
+
+    post "/", params: {
+      jsonrpc: "2.0", id: "arg-test",
+      method: "sparrow/toolsets/list",
+      params: { scope: "read" }
+    }.to_json, headers: json_headers
+
+    assert_response :success
+    assert_equal "sparrow/toolsets/list", received_args[:rpc_method]
+    assert_equal "arg-test", received_args[:id]
+    assert_equal "read", received_args[:params]["scope"]
+    assert_equal "ActionMCP::Server::TransportHandler", received_args[:transport_class]
+  end
+
+  test "handler exception returns internal_error response" do
+    ActionMCP.configuration.custom_method_handler = ->(_method, _id, _params, _transport) {
+      raise StandardError, "kaboom"
+    }
+
+    post "/", params: {
+      jsonrpc: "2.0", id: "err-test",
+      method: "vendor/failing",
+      params: {}
+    }.to_json, headers: json_headers
+
+    assert_response :success
+    body = response.parsed_body
+    assert body["error"]
+    assert_equal(-32_603, body["error"]["code"])
+    assert_includes body["error"]["message"], "Custom method handler error"
+  end
+
+  test "handler-raised JsonRpcError passes through with its own error code" do
+    ActionMCP.configuration.custom_method_handler = ->(_method, _id, _params, _transport) {
+      raise JSON_RPC::JsonRpcError.new(:invalid_params, message: "bad params from handler")
+    }
+
+    post "/", params: {
+      jsonrpc: "2.0", id: "jrpc-err-test",
+      method: "vendor/strict",
+      params: {}
+    }.to_json, headers: json_headers
+
+    assert_response :success
+    body = response.parsed_body
+    assert body["error"]
+    assert_equal(-32_602, body["error"]["code"])
+    assert_includes body["error"]["message"], "bad params from handler"
+  end
+
+  private
+
+  def json_headers
+    {
+      "Content-Type" => "application/json",
+      "Accept" => "application/json",
+      "Mcp-Session-Id" => @session_id
+    }
+  end
+end


### PR DESCRIPTION
## Summary

Applications embedding ActionMCP often need to customize MCP behavior per-session or per-deployment — OAuth scope narrowing, feature flags, vendor-specific JSON-RPC methods — but today the only option is monkey-patching internals. This PR adds two opt-in extension points that let host applications customize behavior cleanly, with no changes to existing behavior when unused.

Both hooks are fully additive: no existing APIs change, no configuration defaults change, and all pre-existing tests continue to pass with identical results.

## Changes

### 1. `filter_tools_list` — session-level display filter

**File:** `lib/action_mcp/server/tools.rb`

After `session.registered_tools` is resolved in `send_tools_list`, the server checks whether the session object responds to `filter_tools_list(tools, params)`. If it does, the return value narrows which tools appear in `tools/list` responses.

```ruby
# In your session class or via define_singleton_method:
def filter_tools_list(tools, params)
  tools.select { |t| current_scopes.include?(t.tool_name) }
end
```

**Design decisions:**

- **Display filter only.** Controls what appears in `tools/list` responses. Does **not** restrict `tools/call` execution — clients can still invoke any registered tool by name. Authorization belongs in the tool or gateway layer, not in a listing filter.
- **Fail-open.** If the filter raises a `StandardError`, returns `nil`, or returns a non-`Array`, the server falls back to the full unfiltered list and logs the error. A buggy filter never breaks tool discoverability.
- **Input sanitization.** Returned array entries are rejected unless they are `Class` objects that respond to `:tool_name`. This prevents accidental pollution from filters that return strings, nils, or other non-tool values.

### 2. `custom_method_handler` — configuration-level callable for vendor methods

**Files:** `lib/action_mcp/configuration.rb`, `lib/action_mcp/server/handlers/custom_method_routing.rb`, `lib/action_mcp/server/handlers/router.rb`, `lib/action_mcp/server/json_rpc_handler.rb`

A global callable that handles vendor-specific JSON-RPC methods (e.g. `myapp/toolsets/list`) that fall outside the core MCP namespaces (`prompts/`, `resources/`, `tools/`, `tasks/`, `completion/complete`, etc.).

```ruby
# config/initializers/action_mcp.rb
ActionMCP.configure do |config|
  config.custom_method_handler = ->(rpc_method, id, params, transport) {
    case rpc_method
    when "myapp/toolsets/list"
      transport.send_jsonrpc_response(id, result: { toolsets: Toolset.all.as_json })
      true
    end
    # Return falsy for unrecognized methods → triggers method_not_found
  }
end
```

**Design decisions:**

- **Truthy/falsy contract.** Return truthy if the method was handled; falsy falls through to `method_not_found`.
- **Assignment validation.** The writer rejects values that don't respond to `#call` (raises `ArgumentError`). `nil` is accepted to clear the handler.
- **Core namespace limitation.** Only invoked for methods outside core MCP namespaces. Core methods are always handled by ActionMCP internals.
- **Shared routing module.** A new `Handlers::CustomMethodRouting` module provides the private `route_custom_method_or_raise` method, included by both `JsonRpcHandler` and `Handlers::Router`. This eliminates inline duplication and ensures identical behavior across both code paths.
- **Error handling.** `StandardError` from the handler is wrapped as a `JsonRpcError(:internal_error)` with a generic message. `JsonRpcError` raised intentionally by the handler is re-raised as-is, so applications can return specific error codes.

## Test coverage

| File | Tests | Covers |
|---|---|---|
| `test/action_mcp/filter_tools_list_test.rb` | 9 | No-op without hook, filters with hook, error fallback, nil/non-array fallback, sanitizes non-class entries, sanitizes non-tool classes, `[nil]` entries, mixed valid/invalid entries |
| `test/action_mcp/custom_method_handler_router_test.rb` | 6 | method_not_found without handler, method_not_found with falsy handler, successful handling, correct arguments, `StandardError` → internal_error, `JsonRpcError` passthrough |
| `test/integration/custom_method_handler_test.rb` | 6 | Same scenarios via full HTTP integration (end-to-end), including `JsonRpcError` passthrough |
| `test/configuration_test.rb` | +4 | Defaults to nil, accepts callable, clearable with nil, rejects non-callable |

**Full suite:** 702 runs, 2864 assertions, **0 failures, 0 errors**, 14 skips. Rubocop: 0 offenses.

## Breaking changes

None. Both hooks are fully additive and opt-in:

- `filter_tools_list` is only invoked if the session object responds to it.
- `custom_method_handler` defaults to `nil`; when nil, behavior is identical to before (unknown methods raise `method_not_found`).
- No existing method signatures, return types, or configuration defaults are changed.
