### PR TITLE
feat: Allow the type option to be either a String or a Symbol

### DIFF
--- a/lib/action_mcp/tool.rb
+++ b/lib/action_mcp/tool.rb
@@ -307,6 +307,7 @@ module ActionMCP
     # @return [void]
     def self.property(prop_name, type: "string", description: nil, required: false, default: nil, **opts)
       # Build the JSON Schema definition.
+      type_str = type.to_s
       prop_definition = { type: type }
       prop_definition[:description] = description if description && !description.empty?
       prop_definition.merge!(opts) if opts.any?
@@ -320,7 +321,7 @@ module ActionMCP
       attribute prop_name, map_json_type_to_active_model_type(type), default: default
       validates prop_name, presence: true, if: -> { required }
 
-      return unless %w[number integer].include?(type)
+      return unless %w[number integer].include?(type_str)
 
       validates prop_name, numericality: true, allow_nil: !required
     end
@@ -629,7 +630,7 @@ module ActionMCP
         next if value.nil? && !self.class._required_properties.include?(key_str)
 
         # Validate based on expected JSON Schema type
-        case expected_type
+        case expected_type.to_s
         when "number"
           validate_number_parameter(key_str, value)
         when "integer"

--- a/test/dummy/app/mcp/tools/symbol_type_tool.rb
+++ b/test/dummy/app/mcp/tools/symbol_type_tool.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SymbolTypeTool < ApplicationMCPTool
+  title "Symbol Type Tool"
+  description "accepts number_a and number_b attributes"
+  read_only
+  idempotent
+  property :number_a, type: :number, required: true
+  property :number_b, type: "number", required: true
+
+  def perform
+    render text: (number_a + number_b).to_s
+  end
+end

--- a/test/tools/symbol_type_tool_test.rb
+++ b/test/tools/symbol_type_tool_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SymbolTypeToolTest < ActiveSupport::TestCase
+  include ActionMCP::TestHelper
+
+  setup do
+    @tool = SymbolTypeTool.new
+  end
+
+  test "tool is registered and available" do
+    assert ActionMCP.tools.key?("symbol_type")
+    assert_equal SymbolTypeTool, ActionMCP.tools["symbol_type"]
+  end
+
+  test "tool metadata is correct" do
+    assert_equal "Symbol Type Tool", SymbolTypeTool.title
+    assert_equal "accepts number_a and number_b attributes", SymbolTypeTool.description
+    assert SymbolTypeTool.read_only?
+    assert SymbolTypeTool.idempotent?
+  end
+
+  test "validates presence of required properties" do
+    tool = SymbolTypeTool.new
+    assert_not tool.valid?
+    assert_includes tool.errors[:number_a], "can't be blank"
+    assert_includes tool.errors[:number_b], "can't be blank"
+  end
+
+  test "validates numericality of properties" do
+    assert_raises(ArgumentError, /number_a must be a number/) {
+      SymbolTypeTool.new(number_a: "not a number")
+    }
+
+    assert_raises(ArgumentError, /number_b must be a number/) {
+      SymbolTypeTool.new(number_a: "not a number")
+    }
+  end
+end


### PR DESCRIPTION
As these sorts of parameters often use Strings and Symbols interchangeably, silently accepting Symbols can lead to unexpected results where validations for integers and numbers would not get created properly.