### PR TITLE
feat: add an option for sending serialized structured content for backwards compatibility

### DIFF
--- a/lib/action_mcp/configuration.rb
+++ b/lib/action_mcp/configuration.rb
@@ -53,7 +53,9 @@ module ActionMCP
                   # --- Allowed identity keys for gateway ---
                   :allowed_identity_keys,
                   # --- JSON-RPC Path ---
-                  :base_path
+                  :base_path,
+                  # --- For backwards compatibility, allow sending serialized structured content in response ---
+                  :include_serialized_structured_content_in_response
 
     def initialize
       @logging_enabled = false

--- a/lib/action_mcp/tool_response.rb
+++ b/lib/action_mcp/tool_response.rb
@@ -23,6 +23,15 @@ module ActionMCP
     # Set structured content for the response
     def set_structured_content(content)
       @structured_content = content
+
+      if ActionMCP.configuration.include_serialized_structured_content_in_response
+        @contents << {
+          type: "text",
+          text: content.to_json
+        }
+      end
+
+      content
     end
 
     # Report a tool execution error (as opposed to protocol error)

--- a/test/action_mcp/include_serialized_structured_content_in_response_test.rb
+++ b/test/action_mcp/include_serialized_structured_content_in_response_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionMCP::IncludeSerializedStructuredContentInResponseTest < ActiveSupport::TestCase
+  setup do
+    @request = ActionDispatch::Request.new({})
+
+    @tool_class = Class.new(ApplicationMCPTool) do
+      tool_name "serialized_structured_content_tool"
+      description "Tool with serialized structured content"
+
+      output_schema do
+        property :name, type: "string", required: true
+        property :count, type: "number", required: true
+      end
+
+      def perform
+        render structured: { name: "test", count: 42 }
+      end
+    end
+  end
+
+  teardown do
+    ActionMCP.configuration.include_serialized_structured_content_in_response = false
+  end
+
+  test "sends serialized structured content in response" do
+    ActionMCP.configuration.include_serialized_structured_content_in_response = true
+
+    tool = @tool_class.new
+    result = tool.call
+
+    assert_equal([ { type: "text", text: '{"name":"test","count":42}' } ], result.contents)
+    assert_equal({ name: "test", count: 42 }, result.structured_content)
+  end
+
+  test "does not send serialized structured content in response when not enabled" do
+    ActionMCP.configuration.include_serialized_structured_content_in_response = false
+
+    tool = @tool_class.new
+    result = tool.call
+
+    assert_equal([], result.contents)
+    assert_equal({ name: "test", count: 42 }, result.structured_content)
+  end
+end


### PR DESCRIPTION
Some LLM services do not utilize `structuredContent` and still rely on serialized JSON in a `TextContent` block. The Current MCP documentation says the following:

```
5.2.6 Structured Content

For backwards compatibility, a tool that returns structured content SHOULD
also return the serialized JSON in a TextContent block.
```

This configuration option allows the structured content to be optionally sent in a `TextContent` block as per the documentation suggestion.