### PR TITLE
feat: Implement static resources for resources/list endpoint

### DIFF
--- a/RESOURCE_TEMPLATES.md
+++ b/RESOURCE_TEMPLATES.md
@@ -1,11 +1,14 @@
 # ActionMCP::ResourceTemplate
 
-A framework for defining URI-templated resources in MCP servers. Handles parameter validation and content resolution.
+A framework for defining URI-templated resources in MCP servers. Handles parameter validation, content resolution, and static resource listing.
+
+> **Client compatibility note:** Not all MCP clients support both resource endpoints. Claude Code (as of v2.1.50) only calls `resources/list` (not `resources/templates/list`), and Codex stubs resource methods entirely. If your resources should be visible across clients, you **must** implement `self.list` on your templates. Crush and VS Code support both endpoints.
 
 ## Usage
 
+### Basic Template with resolve
+
 ```ruby
-# Basic resource template
 class ProductTemplate < ApplicationMCPResTemplate
   description "Access product data"
   uri_template "store://products/{id}"
@@ -25,8 +28,49 @@ class ProductTemplate < ApplicationMCPResTemplate
     )
   end
 end
+```
 
-# Nested/related resource template
+### Static Resource Listing
+
+Templates can enumerate concrete resources for `resources/list` by overriding `self.list`:
+
+```ruby
+class ProductTemplate < ApplicationMCPResTemplate
+  description "Access product data"
+  uri_template "store://products/{id}"
+  mime_type "application/json"
+
+  parameter :id, description: "Product ID", required: true
+
+  # Enumerate concrete resources for resources/list
+  def self.list(session: nil)
+    Product.limit(100).map do |product|
+      build_resource(
+        uri: "store://products/#{product.id}",
+        name: product.name,
+        title: "Product ##{product.id}",
+        description: "Product: #{product.name}",
+        size: product.data.bytesize
+      )
+    end
+  end
+
+  def resolve
+    product = Product.find_by(id: id)
+    return nil unless product
+
+    ActionMCP::Content::Resource.new(
+      "store://products/#{id}",
+      mime_type,
+      text: product.to_json
+    )
+  end
+end
+```
+
+### Nested/Related Resource Template
+
+```ruby
 class ProductCertificatesTemplate < ApplicationMCPResTemplate
   description "Access certificates for a product"
   uri_template "store://products/{id}/certificates"
@@ -54,11 +98,86 @@ end
 
 ## Key Methods
 
+### Class Methods
+
 - `description` - Sets human-readable template description
 - `uri_template` - Defines RFC 6570 URI pattern with parameters
 - `mime_type` - Sets content type for resources
 - `parameter(name, description:, required:)` - Declares URI parameters
+- `list(session:)` - Override to enumerate concrete resources for `resources/list`
+- `lists_resources?` - Returns true if `list` is overridden
+- `build_resource(uri:, name:, **opts)` - Factory helper that inherits template defaults
+- `readable_uri?(uri)` - Check if a URI matches and validates against this template
+
+### Instance Methods
+
 - `resolve` - Returns resource content (single resource, array, or nil)
+
+## Static Resources (`resources/list`)
+
+The MCP spec defines two resource surfaces:
+
+- **`resources/list`** — concrete resources with known URIs
+- **`resources/templates/list`** — parameterized URI patterns
+
+Override `self.list(session:)` to expose concrete resources. Each listed URI must be readable by the same template (validated via `readable_uri?`).
+
+### `build_resource` Helper
+
+`build_resource` creates `ActionMCP::Resource` instances with template defaults:
+
+```ruby
+def self.list(session: nil)
+  [
+    build_resource(uri: "store://products/1", name: "Widget"),
+    build_resource(uri: "store://products/2", name: "Gadget", title: "The Gadget")
+  ]
+end
+```
+
+Fields `description` and `mime_type` fall back to the template's values if not provided.
+
+### Deduplication and Collision Rules
+
+- Resources are deduplicated by URI across all templates
+- If two templates list the same URI with identical metadata, the duplicate is silently dropped
+- If two templates list the same URI with different metadata, a JSON-RPC error is returned
+
+### Cursor Pagination
+
+Both `resources/list` and `resources/templates/list` support cursor-based pagination:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{"cursor":"MTA="}}
+```
+
+The response includes `nextCursor` when more results are available.
+
+## Read Contract (`resources/read`)
+
+`resolve` should return `ActionMCP::Content::Resource` for MCP-compliant read output:
+
+```ruby
+def resolve
+  ActionMCP::Content::Resource.new(uri, mime_type, text: data.to_json)
+end
+```
+
+The response shape is:
+
+```json
+{
+  "contents": [
+    { "uri": "store://products/1", "mimeType": "application/json", "text": "{...}" }
+  ]
+}
+```
+
+For binary resources, use `blob:` instead of `text:`:
+
+```ruby
+ActionMCP::Content::Resource.new(uri, "image/png", blob: Base64.strict_encode64(image_data))
+```
 
 ## Implementation Notes
 
@@ -68,13 +187,12 @@ end
 - Each resource in collection has unique URI
 - Parameters extracted from URI template are accessible as methods
 - Standard Rails validations apply to parameters
-
-Templates enable structured resource access through standardized URI patterns.
+- Listed URIs are validated against the declaring template's pattern
 
 ## Callbacks
 
-Resource templates support callbacks that allow you to perform actions before, after, or around the `resolve` method.
+Resource templates support callbacks around the `resolve` method:
 
-- `before_resolve` - Called before the `resolve` method is executed.
-- `after_resolve` - Called after the `resolve` method is executed.
-- `around_resolve` - Called around the `resolve` method, allowing you to wrap the execution of the method.
+- `before_resolve` - Called before `resolve`
+- `after_resolve` - Called after `resolve`
+- `around_resolve` - Wraps `resolve` execution

--- a/lib/action_mcp/resource.rb
+++ b/lib/action_mcp/resource.rb
@@ -2,21 +2,56 @@
 
 module ActionMCP
   # Represents a resource with its metadata.
-  Resource = Data.define(:uri, :name, :description, :mime_type, :size) do
+  # Used by resources/list to describe concrete resources.
+  class Resource
+    attr_reader :uri, :name, :title, :description, :mime_type, :size, :annotations
+
+    # @param uri [String] The URI of the resource
+    # @param name [String] Display name of the resource
+    # @param title [String, nil] Human-readable title
+    # @param description [String, nil] Description of the resource
+    # @param mime_type [String, nil] MIME type of the resource content
+    # @param size [Integer, nil] Size of the resource in bytes
+    # @param annotations [Hash, nil] Optional annotations
+    def initialize(uri:, name:, title: nil, description: nil, mime_type: nil, size: nil, annotations: nil)
+      @uri = uri
+      @name = name
+      @title = title
+      @description = description
+      @mime_type = mime_type
+      @size = size
+      @annotations = annotations
+      freeze
+    end
+
     # Convert the resource to a hash with the keys expected by MCP.
     # Note: The key for mime_type is converted to 'mimeType' as specified.
     #
     # @return [Hash] A hash representation of the resource.
     def to_h
       hash = { uri: uri, name: name }
+      hash[:title] = title if title
       hash[:description] = description if description
-      hash[:mimeType]   = mime_type if mime_type
-      hash[:size]       = size if size
+      hash[:mimeType] = mime_type if mime_type
+      hash[:size] = size if size
+      hash[:annotations] = annotations if annotations
       hash
     end
 
     def to_json(*)
       MultiJson.dump(to_h, *)
+    end
+
+    def ==(other)
+      other.is_a?(Resource) && uri == other.uri && name == other.name &&
+        title == other.title && description == other.description &&
+        mime_type == other.mime_type && size == other.size &&
+        annotations == other.annotations
+    end
+    alias eql? ==
+
+    def hash
+      [ uri, name, title, description, mime_type, size, annotations ].hash
     end
   end
 end

--- a/lib/action_mcp/resource_templates_registry.rb
+++ b/lib/action_mcp/resource_templates_registry.rb
@@ -22,7 +22,8 @@ module ActionMCP
         ResourceTemplate
       end
 
-      # Find the most specific template for a given URI
+      # Find the most specific template for a given URI.
+      # Uses registry-backed source (not ResourceTemplate.registered_templates class array).
       def find_template_for_uri(uri)
         parse_result = parse_uri(uri)
         return nil unless parse_result
@@ -31,7 +32,7 @@ module ActionMCP
         path = parse_result[:path]
         path_segments = path.split("/")
 
-        matching_templates = ResourceTemplate.registered_templates.select do |template|
+        matching_templates = resource_templates.values.select do |template|
           next unless template.uri_template
 
           # Parse the template

--- a/lib/action_mcp/server/handlers/resource_handler.rb
+++ b/lib/action_mcp/server/handlers/resource_handler.rb
@@ -32,12 +32,12 @@ module ActionMCP
           }
         end
 
-        def handle_resources_list(id, _params)
-          transport.send_resources_list(id)
+        def handle_resources_list(id, params)
+          transport.send_resources_list(id, params)
         end
 
-        def handle_resources_templates_list(id, _params)
-          transport.send_resource_templates_list(id)
+        def handle_resources_templates_list(id, params)
+          transport.send_resource_templates_list(id, params)
         end
 
         def handle_resources_read(id, params)

--- a/lib/action_mcp/server/resources.rb
+++ b/lib/action_mcp/server/resources.rb
@@ -3,59 +3,112 @@
 module ActionMCP
   module Server
     module Resources
-      # Send list of available resources to the client
+      # Default page size for cursor-based pagination
+      RESOURCES_PAGE_SIZE = 100
+
+      # Send list of concrete resources to the client.
+      # Aggregates resources from templates that implement self.list.
       #
       # @param request_id [String, Integer] The ID of the request to respond to
-      #
-      # @example Input:
-      #   request_id = "req-123"
-      #
-      # @example Output:
-      #   # Sends: {"jsonrpc":"2.0","id":"req-123","result":{"resources":[]}}
-      def send_resources_list(request_id)
-        send_jsonrpc_response(request_id, result: { resources: [] })
+      # @param params [Hash] Optional params including "cursor" for pagination
+      def send_resources_list(request_id, params = {})
+        templates = session.registered_resource_templates
+
+        # Collect resources from templates that implement list
+        all_resources = []
+        seen_uris = {}
+
+        templates.each do |template_class|
+          next unless template_class.lists_resources?
+
+          begin
+            listed = template_class.list(session: session)
+          rescue StandardError => e
+            Rails.logger.error "[MCP] Error listing resources from #{template_class.name}: #{e.message}"
+            next
+          end
+
+          unless listed.is_a?(Array)
+            Rails.logger.warn "[MCP] #{template_class.name}.list returned #{listed.class}, expected Array; skipping"
+            next
+          end
+
+          listed.each do |resource|
+            unless resource.is_a?(ActionMCP::Resource)
+              Rails.logger.warn "[MCP] #{template_class.name}.list returned non-Resource: #{resource.class}"
+              next
+            end
+
+            # Validate the listed URI is readable by the declaring template
+            unless template_class.readable_uri?(resource.uri)
+              Rails.logger.warn "[MCP] #{template_class.name}.list returned URI not readable by its own template: #{resource.uri}"
+              next
+            end
+
+            # Deduplicate by URI
+            if (existing = seen_uris[resource.uri])
+              if existing == resource
+                # Identical duplicate, skip silently
+                next
+              else
+                # Conflicting metadata for same URI
+                send_jsonrpc_error(request_id, :invalid_params,
+                  "Resource URI collision: '#{resource.uri}' listed by multiple templates with conflicting metadata")
+                return
+              end
+            end
+
+            seen_uris[resource.uri] = resource
+            all_resources << resource
+          end
+        end
+
+        # Apply cursor-based pagination
+        result = paginate_resources(all_resources, params["cursor"])
+        if result == :invalid_cursor
+          send_jsonrpc_error(request_id, :invalid_params, "Invalid cursor value")
+          return
+        end
+        send_jsonrpc_response(request_id, result: result)
       end
 
       # Send list of resource templates to the client
       #
       # @param request_id [String, Integer] The ID of the request to respond to
-      #
-      # @example Input:
-      #   request_id = "req-456"
-      #
-      # @example Output:
-      #   # Sends: {"jsonrpc":"2.0","id":"req-456","result":{"resourceTemplates":[{"uriTemplate":"db://{table}","name":"Database Table"}]}}
-      def send_resource_templates_list(request_id)
-        templates = ActionMCP::ResourceTemplatesRegistry.resource_templates.values.map(&:to_h)
-        # TODO: add pagination support
-        # TODO add autocomplete
+      # @param params [Hash] Optional params including "cursor" for pagination
+      def send_resource_templates_list(request_id, params = {})
+        templates = session.registered_resource_templates.map(&:to_h)
         log_resource_templates
-        send_jsonrpc_response(request_id, result: { resourceTemplates: templates })
+
+        # Apply cursor-based pagination
+        result = paginate_templates(templates, params["cursor"])
+        if result == :invalid_cursor
+          send_jsonrpc_error(request_id, :invalid_params, "Invalid cursor value")
+          return
+        end
+        send_jsonrpc_response(request_id, result: result)
       end
 
       # Read and return the contents of a resource
       #
       # @param id [String, Integer] The ID of the request to respond to
       # @param params [Hash] Parameters specifying which resource to read
-      #
-      # @example Input:
-      #   id = "req-789"
-      #   params = { uri: "file:///example.txt" }
-      #
-      # @example Output:
-      #   # Sends: {"jsonrpc":"2.0","id":"req-789","result":{"contents":[{"uri":"file:///example.txt","text":"Example content"}]}}
       def send_resource_read(id, params)
         uri = params["uri"]
         template = ResourceTemplatesRegistry.find_template_for_uri(uri)
 
         unless template
-          send_jsonrpc_error(id, :method_not_found, "No resource template found for URI: '#{uri}'")
+          error = {
+            code: -32_002,
+            message: "Resource not found",
+            data: { uri: uri }
+          }
+          send_jsonrpc_response(id, error: error)
           return
         end
 
         # Check if resource requires consent and if consent is granted
         if template.respond_to?(:requires_consent?) && template.requires_consent? && !session.consent_granted_for?("resource:#{template.name}")
-          # Use custom error response for consent required (-32002)
           error = {
             code: -32_002,
             message: "Consent required for resource template '#{template.name}'"
@@ -64,22 +117,41 @@ module ActionMCP
           return
         end
 
+        unless template.readable_uri?(uri)
+          error = {
+            code: -32_002,
+            message: "Resource not found",
+            data: { uri: uri }
+          }
+          send_jsonrpc_response(id, error: error)
+          return
+        end
+
         begin
           # Create template instance and set execution context
           record = template.process(uri)
+          unless record
+            error = {
+              code: -32_002,
+              message: "Resource not found",
+              data: { uri: uri }
+            }
+            send_jsonrpc_response(id, error: error)
+            return
+          end
+
           record.with_context({ session: session })
 
           response = record.call
 
           if response.error?
-            # response.to_h works properly when error? is true:
             send_jsonrpc_response(id, error: response.to_h)
           else
-            # Handle successful response - ResourceResponse.contents is already an array
-            send_jsonrpc_response(id, result: { contents: response.contents.map(&:to_h) })
+            # Normalize contents to MCP ReadResourceResult shape
+            contents = response.contents.map { |c| normalize_read_content(c, uri) }
+            send_jsonrpc_response(id, result: { contents: contents })
           end
         rescue StandardError => e
-          # Should rather `ErrorHandling` module be included here? Then we could use `log_error(e)` directly.
           Rails.logger.error "[MCP Error] #{e.class}: #{e.message}"
           send_jsonrpc_error(id, :internal_error, "Failed to read resource: #{e.message}")
         end
@@ -87,13 +159,83 @@ module ActionMCP
 
       private
 
+      # Normalize a content object to MCP ReadResourceResult content shape.
+      #
+      # @return [Hash] with keys: uri, mimeType, and text or blob
+      def normalize_read_content(content, _uri)
+        case content
+        when ActionMCP::Content::Resource
+          inner = { uri: content.uri, mimeType: content.mime_type }
+          inner[:text] = content.text if content.text
+          inner[:blob] = content.blob if content.blob
+          inner
+        else
+          content.respond_to?(:to_h) ? content.to_h : content
+        end
+      end
+
+      # Paginate a list of resources with cursor support.
+      #
+      # @param resources [Array<ActionMCP::Resource>] All resources
+      # @param cursor [String, nil] Base64-encoded offset cursor
+      # @return [Hash] Result hash with :resources and optional :nextCursor
+      def paginate_resources(resources, cursor)
+        offset = decode_cursor(cursor)
+        return :invalid_cursor if offset == :invalid
+
+        page = resources[offset, RESOURCES_PAGE_SIZE] || []
+
+        result = { resources: page.map(&:to_h) }
+
+        next_offset = offset + RESOURCES_PAGE_SIZE
+        if next_offset < resources.size
+          result[:nextCursor] = encode_cursor(next_offset)
+        end
+
+        result
+      end
+
+      # Paginate a list of templates with cursor support.
+      #
+      # @param templates [Array<Hash>] All template hashes
+      # @param cursor [String, nil] Base64-encoded offset cursor
+      # @return [Hash] Result hash with :resourceTemplates and optional :nextCursor
+      def paginate_templates(templates, cursor)
+        offset = decode_cursor(cursor)
+        return :invalid_cursor if offset == :invalid
+
+        page = templates[offset, RESOURCES_PAGE_SIZE] || []
+
+        result = { resourceTemplates: page }
+
+        next_offset = offset + RESOURCES_PAGE_SIZE
+        if next_offset < templates.size
+          result[:nextCursor] = encode_cursor(next_offset)
+        end
+
+        result
+      end
+
+      # Decode a cursor string to a non-negative integer offset.
+      # Returns 0 for nil cursors, :invalid for malformed/negative/non-string values.
+      def decode_cursor(cursor)
+        return 0 if cursor.nil?
+        return :invalid unless cursor.is_a?(String) && !cursor.empty?
+
+        decoded = Base64.strict_decode64(cursor)
+        return :invalid unless decoded.match?(/\A\d+\z/)
+
+        decoded.to_i
+      rescue ArgumentError
+        :invalid
+      end
+
+      # Encode an integer offset as a cursor string.
+      def encode_cursor(offset)
+        Base64.strict_encode64(offset.to_s)
+      end
+
       # Log all registered resource templates
-      #
-      # @example Input:
-      #   # No parameters
-      #
-      # @example Output:
-      #   # Logs: "Registered Resource Templates: ["db://{table}", "file://{path}"]"
       def log_resource_templates
         Rails.logger.debug "Registered Resource Templates: #{ActionMCP::ResourceTemplatesRegistry.resource_templates.keys}"
       end

--- a/test/action_mcp/resource_template_list_test.rb
+++ b/test/action_mcp/resource_template_list_test.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionMCP
+  class ResourceTemplateListTest < ActiveSupport::TestCase
+    def setup
+      @original_templates = ResourceTemplate.registered_templates.dup
+      ResourceTemplate.instance_variable_set(:@registered_templates, [])
+    end
+
+    def teardown
+      ResourceTemplate.instance_variable_set(:@registered_templates, @original_templates)
+    end
+
+    test "default list returns empty array" do
+      template = Class.new(ResourceTemplate) do
+        def self.name = "EmptyTemplate"
+        uri_template "test://items/{id}"
+        description "Test"
+      end
+
+      assert_equal [], template.list
+      assert_equal [], template.list(session: nil)
+    end
+
+    test "lists_resources? returns false for base class" do
+      template = Class.new(ResourceTemplate) do
+        def self.name = "NoListTemplate"
+        uri_template "test://things/{id}"
+        description "No list"
+      end
+
+      refute template.lists_resources?
+    end
+
+    test "lists_resources? returns true when list is overridden" do
+      template = Class.new(ResourceTemplate) do
+        def self.name = "WithListTemplate"
+        uri_template "test://widgets/{id}"
+        description "With list"
+
+        def self.list(session: nil)
+          [ build_resource(uri: "test://widgets/1", name: "Widget 1") ]
+        end
+      end
+
+      assert template.lists_resources?
+    end
+
+    test "build_resource creates Resource with template defaults" do
+      template = Class.new(ResourceTemplate) do
+        def self.name = "DefaultsTemplate"
+        uri_template "test://docs/{id}"
+        description "Documentation resource"
+        mime_type "text/markdown"
+      end
+
+      resource = template.build_resource(uri: "test://docs/1", name: "Doc 1")
+
+      assert_instance_of Resource, resource
+      assert_equal "test://docs/1", resource.uri
+      assert_equal "Doc 1", resource.name
+      assert_equal "Documentation resource", resource.description
+      assert_equal "text/markdown", resource.mime_type
+    end
+
+    test "build_resource allows overriding defaults" do
+      template = Class.new(ResourceTemplate) do
+        def self.name = "OverrideTemplate"
+        uri_template "test://files/{path}"
+        description "Default desc"
+        mime_type "text/plain"
+      end
+
+      resource = template.build_resource(
+        uri: "test://files/readme",
+        name: "README",
+        description: "Custom desc",
+        mime_type: "text/markdown",
+        title: "The README",
+        size: 1024,
+        annotations: { priority: 1.0 }
+      )
+
+      assert_equal "Custom desc", resource.description
+      assert_equal "text/markdown", resource.mime_type
+      assert_equal "The README", resource.title
+      assert_equal 1024, resource.size
+      assert_equal({ priority: 1.0 }, resource.annotations)
+    end
+
+    test "readable_uri? returns true for valid URI" do
+      template = Class.new(ResourceTemplate) do
+        def self.name = "ReadableTemplate"
+        uri_template "test://items/{id}"
+        description "Test"
+        parameter :id, description: "ID", required: true
+      end
+
+      assert template.readable_uri?("test://items/123")
+    end
+
+    test "readable_uri? returns false for non-matching URI" do
+      template = Class.new(ResourceTemplate) do
+        def self.name = "NonMatchTemplate"
+        uri_template "test://items/{id}"
+        description "Test"
+        parameter :id, description: "ID", required: true
+      end
+
+      refute template.readable_uri?("other://items/123")
+      refute template.readable_uri?("test://different/123")
+    end
+
+    test "readable_uri? returns false for mismatched URI on no-param template" do
+      template = Class.new(ResourceTemplate) do
+        def self.name = "StaticTemplate"
+        uri_template "test://status"
+        description "Static status endpoint"
+      end
+
+      assert template.readable_uri?("test://status")
+      refute template.readable_uri?("test://other/path")
+      refute template.readable_uri?("other://status")
+    end
+  end
+end

--- a/test/action_mcp/resource_templates_registry_test.rb
+++ b/test/action_mcp/resource_templates_registry_test.rb
@@ -5,40 +5,48 @@ require "test_helper"
 module ActionMCP
   class ResourceTemplatesRegistryTest < ActiveSupport::TestCase
     def setup
-      # Save original registered templates
+      # Save original state
       @original_templates = ResourceTemplate.registered_templates.dup
+      @original_registry = ResourceTemplatesRegistry.items.dup
+
       # Clear for testing
       ResourceTemplate.instance_variable_set(:@registered_templates, [])
+      ResourceTemplatesRegistry.instance_variable_set(:@items, {})
 
-      # Create some test templates
+      # Create and register test templates
       @user_profile_template = Class.new(ResourceTemplate) do
         def self.name = "UserProfileTemplate"
         uri_template "service://users/{id}/profile"
         description "User profile"
       end
+      ResourceTemplatesRegistry.register(@user_profile_template)
 
       @user_template = Class.new(ResourceTemplate) do
         def self.name = "UserTemplate"
         uri_template "service://users/{id}"
         description "User resource"
       end
+      ResourceTemplatesRegistry.register(@user_template)
 
       @product_template = Class.new(ResourceTemplate) do
         def self.name = "ProductTemplate"
         uri_template "service://products/{id}"
         description "Product resource"
       end
+      ResourceTemplatesRegistry.register(@product_template)
 
       @category_products_template = Class.new(ResourceTemplate) do
         def self.name = "CategoryProductsTemplate"
         uri_template "service://categories/{category_id}/products"
         description "Products in a category"
       end
+      ResourceTemplatesRegistry.register(@category_products_template)
     end
 
     def teardown
-      # Restore original registered templates
+      # Restore original state
       ResourceTemplate.instance_variable_set(:@registered_templates, @original_templates)
+      ResourceTemplatesRegistry.instance_variable_set(:@items, @original_registry)
     end
 
     test "finds the correct template for a URI" do
@@ -72,6 +80,7 @@ module ActionMCP
         uri_template "service://users/admin/profile"
         description "Admin user profile"
       end
+      ResourceTemplatesRegistry.register(specific_template)
 
       # This should match the specific template
       uri = "service://users/admin/profile"

--- a/test/action_mcp/resource_test.rb
+++ b/test/action_mcp/resource_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionMCP
+  class ResourceTest < ActiveSupport::TestCase
+    test "creates resource with all fields" do
+      resource = Resource.new(
+        uri: "file:///test.txt",
+        name: "test.txt",
+        title: "Test File",
+        description: "A test file",
+        mime_type: "text/plain",
+        size: 42,
+        annotations: { audience: [ "user" ] }
+      )
+
+      assert_equal "file:///test.txt", resource.uri
+      assert_equal "test.txt", resource.name
+      assert_equal "Test File", resource.title
+      assert_equal "A test file", resource.description
+      assert_equal "text/plain", resource.mime_type
+      assert_equal 42, resource.size
+      assert_equal({ audience: [ "user" ] }, resource.annotations)
+    end
+
+    test "creates resource with only required fields" do
+      resource = Resource.new(uri: "file:///test.txt", name: "test.txt")
+
+      assert_equal "file:///test.txt", resource.uri
+      assert_equal "test.txt", resource.name
+      assert_nil resource.title
+      assert_nil resource.description
+      assert_nil resource.mime_type
+      assert_nil resource.size
+      assert_nil resource.annotations
+    end
+
+    test "backward compatibility with existing callers" do
+      # Existing code uses uri:, name:, description:, mime_type:, size:
+      resource = Resource.new(
+        uri: "ecommerce://products/1",
+        name: "Product 1",
+        description: "A product",
+        mime_type: "application/json",
+        size: 100
+      )
+
+      assert_equal "ecommerce://products/1", resource.uri
+      assert_equal "Product 1", resource.name
+      assert_equal "A product", resource.description
+      assert_equal "application/json", resource.mime_type
+      assert_equal 100, resource.size
+    end
+
+    test "to_h includes only present fields" do
+      resource = Resource.new(uri: "file:///test.txt", name: "test.txt")
+      hash = resource.to_h
+
+      assert_equal({ uri: "file:///test.txt", name: "test.txt" }, hash)
+    end
+
+    test "to_h converts mime_type to mimeType" do
+      resource = Resource.new(
+        uri: "file:///test.txt",
+        name: "test.txt",
+        mime_type: "text/plain"
+      )
+
+      assert_equal "text/plain", resource.to_h[:mimeType]
+      assert_nil resource.to_h[:mime_type]
+    end
+
+    test "to_h includes title and annotations when present" do
+      resource = Resource.new(
+        uri: "file:///test.txt",
+        name: "test.txt",
+        title: "Test File",
+        annotations: { priority: 0.5 }
+      )
+
+      hash = resource.to_h
+      assert_equal "Test File", hash[:title]
+      assert_equal({ priority: 0.5 }, hash[:annotations])
+    end
+
+    test "equality comparison" do
+      r1 = Resource.new(uri: "file:///a.txt", name: "a")
+      r2 = Resource.new(uri: "file:///a.txt", name: "a")
+      r3 = Resource.new(uri: "file:///b.txt", name: "b")
+
+      assert_equal r1, r2
+      refute_equal r1, r3
+    end
+
+    test "resources are frozen" do
+      resource = Resource.new(uri: "file:///test.txt", name: "test.txt")
+      assert resource.frozen?
+    end
+
+    test "to_json produces valid JSON" do
+      resource = Resource.new(
+        uri: "file:///test.txt",
+        name: "test.txt",
+        mime_type: "text/plain"
+      )
+
+      parsed = JSON.parse(resource.to_json)
+      assert_equal "file:///test.txt", parsed["uri"]
+      assert_equal "test.txt", parsed["name"]
+      assert_equal "text/plain", parsed["mimeType"]
+    end
+  end
+end

--- a/test/action_mcp/server/resources_test.rb
+++ b/test/action_mcp/server/resources_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionMCP
+  module Server
+    class ResourcesTest < ActiveSupport::TestCase
+      class TestSession
+        attr_reader :registered_resource_templates
+
+        def initialize
+          @registered_resource_templates = []
+        end
+
+        def consent_granted_for?(_key)
+          true
+        end
+      end
+
+      class TestTransport
+        include Resources
+
+        attr_reader :responses, :errors
+
+        def initialize
+          @session = TestSession.new
+          @responses = []
+          @errors = []
+        end
+
+        def session
+          @session
+        end
+
+        def send_jsonrpc_response(id, result: nil, error: nil)
+          @responses << { id: id, result: result, error: error }
+        end
+
+        def send_jsonrpc_error(id, symbol, message, data = nil)
+          @errors << { id: id, symbol: symbol, message: message, data: data }
+        end
+      end
+
+      test "send_resource_read returns not found when template does not accept URI" do
+        transport = TestTransport.new
+        uri = "demo://resource/1"
+        template = Class.new do
+          def self.name = "UnreadableTemplate"
+          def self.readable_uri?(_uri) = false
+        end
+
+        ActionMCP::ResourceTemplatesRegistry.stub(:find_template_for_uri, template) do
+          transport.send_resource_read(100, { "uri" => uri })
+        end
+
+        response = transport.responses.last
+        assert_nil response[:result]
+        assert_equal(-32_002, response[:error][:code])
+        assert_equal "Resource not found", response[:error][:message]
+        assert_equal({ uri: uri }, response[:error][:data])
+      end
+    end
+  end
+end

--- a/test/dummy/app/mcp/resource_templates/orders_template.rb
+++ b/test/dummy/app/mcp/resource_templates/orders_template.rb
@@ -35,12 +35,12 @@ class OrdersTemplate < ApplicationMCPResTemplate
     order = MockOrder.find_by(id: order_id)
     return unless order
 
-    ActionMCP::Resource.new(
-      uri: "ecommerce://orders/#{order_id}",
-      name: "Order #{order_id}",
-      description: "Order information for order #{order_id}",
-      mime_type: "application/json",
-      size: order.to_json.length
+    data = { id: order.id, customer_id: customer_id }
+
+    ActionMCP::Content::Resource.new(
+      "ecommerce://customers/#{customer_id}/orders/#{order_id}",
+      "application/json",
+      text: data.to_json
     )
   end
 end

--- a/test/dummy/app/mcp/resource_templates/products_template.rb
+++ b/test/dummy/app/mcp/resource_templates/products_template.rb
@@ -28,16 +28,29 @@ class ProductsTemplate < ApplicationMCPResTemplate
     response
   end
 
+  # Enumerate concrete products for resources/list
+  def self.list(session: nil)
+    # Return a few well-known products as static resources
+    [ 1, 2, 3 ].map do |id|
+      build_resource(
+        uri: "ecommerce://products/#{id}",
+        name: "Product #{id}",
+        title: "Product ##{id}",
+        description: "Product information for product #{id}"
+      )
+    end
+  end
+
   def resolve
     product = MockProduct.find_by(id: product_id)
     return unless product
 
-    ActionMCP::Resource.new(
-      uri: "ecommerce://products/#{product_id}",
-      name: "Product #{product_id}",
-      description: "Product information for product #{product_id}",
-      mime_type: "application/json",
-      size: product.to_json.length
+    data = { id: product.id, name: "Product #{product_id}" }
+
+    ActionMCP::Content::Resource.new(
+      "ecommerce://products/#{product_id}",
+      "application/json",
+      text: data.to_json
     )
   end
 end

--- a/test/dummy/app/mcp/tools/session_info_tool.rb
+++ b/test/dummy/app/mcp/tools/session_info_tool.rb
@@ -21,7 +21,11 @@ class SessionInfoTool < ApplicationMCPTool
 
   def extract_client_info(total_seconds)
     total_seconds = total_seconds.to_i
-    info = { name: "unknown entity", version: "Unknown Version" }
+    raw = session.client_info || {}
+    info = {
+      name: raw["name"] || raw[:name] || "unknown entity",
+      version: raw["version"] || raw[:version] || "Unknown Version"
+    }
 
     info[:security_risk] = total_seconds > 300 ? "HIGH - Client has been compromised" : "LOW"
     info[:memory_leaks_detected] = rand(1..17)

--- a/test/dummy/app/models/mock_order.rb
+++ b/test/dummy/app/models/mock_order.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class MockOrder
+  def self.find_by(id:)
+    new(id: id) if id.to_i.positive?
+  end
+
+  attr_reader :id
+
+  def initialize(id:)
+    @id = id
+  end
+
+  def to_json(*_args)
+    { id: id }.to_json
+  end
+end

--- a/test/dummy/app/models/mock_product.rb
+++ b/test/dummy/app/models/mock_product.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class MockProduct
+  def self.find_by(id:)
+    new(id: id) if id.to_i.positive?
+  end
+
+  attr_reader :id
+
+  def initialize(id:)
+    @id = id
+  end
+
+  def to_json(*_args)
+    { id: id }.to_json
+  end
+end

--- a/test/integration/resources_list_test.rb
+++ b/test/integration/resources_list_test.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionMCP
+  class ResourcesListTest < ActionDispatch::IntegrationTest
+    setup do
+      # Initialize session
+      post action_mcp.mcp_post_path,
+           params: {
+             jsonrpc: "2.0",
+             id: 1,
+             method: "initialize",
+             params: {
+               clientInfo: { name: "test", version: "1.0" },
+               protocolVersion: ActionMCP::LATEST_VERSION
+             }
+           }.to_json,
+           headers: { "Content-Type" => "application/json", "Accept" => "application/json" }
+
+      assert_response :success
+      session_id = response.headers["Mcp-Session-Id"]
+      assert_not_nil session_id
+
+      # Complete initialization
+      post action_mcp.mcp_post_path,
+           params: {
+             jsonrpc: "2.0",
+             method: "notifications/initialized"
+           }.to_json,
+           headers: {
+             "Content-Type" => "application/json",
+             "Accept" => "application/json",
+             "Mcp-Session-Id" => session_id
+           }
+
+      assert_response :accepted
+      @session_id = session_id
+    end
+
+    test "resources/list returns concrete resources from templates implementing list" do
+      post action_mcp.mcp_post_path,
+           params: {
+             jsonrpc: "2.0",
+             id: 2,
+             method: "resources/list"
+           }.to_json,
+           headers: {
+             "Content-Type" => "application/json",
+             "Accept" => "application/json",
+             "Mcp-Session-Id" => @session_id
+           }
+
+      assert_response :success
+      result = JSON.parse(response.body)
+
+      assert_equal "2.0", result["jsonrpc"]
+      assert_equal 2, result["id"]
+      assert_nil result["error"], "Expected no error, but got: #{result["error"]}"
+      assert_not_nil result["result"]
+      assert_not_nil result["result"]["resources"]
+
+      resources = result["result"]["resources"]
+      # ProductsTemplate lists 3 products
+      product_uris = resources.select { |r| r["uri"].start_with?("ecommerce://products/") }
+      assert_equal 3, product_uris.size
+
+      # Verify resource shape
+      product = product_uris.find { |r| r["uri"] == "ecommerce://products/1" }
+      assert_not_nil product
+      assert_equal "Product 1", product["name"]
+      assert_equal "Product #1", product["title"]
+      assert_equal "application/json", product["mimeType"]
+    end
+
+    test "resources/list supports cursor pagination" do
+      post action_mcp.mcp_post_path,
+           params: {
+             jsonrpc: "2.0",
+             id: 2,
+             method: "resources/list",
+             params: {}
+           }.to_json,
+           headers: {
+             "Content-Type" => "application/json",
+             "Accept" => "application/json",
+             "Mcp-Session-Id" => @session_id
+           }
+
+      assert_response :success
+      result = JSON.parse(response.body)
+
+      # With few resources, no nextCursor should be present
+      assert_nil result["result"]["nextCursor"]
+    end
+
+    test "resources/list returns invalid params for malformed cursor" do
+      post action_mcp.mcp_post_path,
+           params: {
+             jsonrpc: "2.0",
+             id: 22,
+             method: "resources/list",
+             params: { cursor: "not-base64" }
+           }.to_json,
+           headers: {
+             "Content-Type" => "application/json",
+             "Accept" => "application/json",
+             "Mcp-Session-Id" => @session_id
+           }
+
+      assert_response :success
+      result = JSON.parse(response.body)
+
+      assert_not_nil result["error"]
+      assert_equal(-32_602, result["error"]["code"])
+      assert_match(/Invalid cursor value/, result["error"]["message"])
+    end
+
+    test "resources/templates/list returns templates" do
+      post action_mcp.mcp_post_path,
+           params: {
+             jsonrpc: "2.0",
+             id: 3,
+             method: "resources/templates/list"
+           }.to_json,
+           headers: {
+             "Content-Type" => "application/json",
+             "Accept" => "application/json",
+             "Mcp-Session-Id" => @session_id
+           }
+
+      assert_response :success
+      result = JSON.parse(response.body)
+
+      assert_not_nil result["result"]
+      templates = result["result"]["resourceTemplates"]
+      assert_not_nil templates
+      assert templates.size > 0
+
+      # Verify template shape
+      template = templates.find { |t| t["uriTemplate"]&.include?("products") }
+      assert_not_nil template, "Expected to find products template"
+      assert_not_nil template["uriTemplate"]
+      assert_not_nil template["name"]
+    end
+
+    test "resources/templates/list accepts cursor param without error" do
+      post action_mcp.mcp_post_path,
+           params: {
+             jsonrpc: "2.0",
+             id: 4,
+             method: "resources/templates/list",
+             params: { cursor: nil }
+           }.to_json,
+           headers: {
+             "Content-Type" => "application/json",
+             "Accept" => "application/json",
+             "Mcp-Session-Id" => @session_id
+           }
+
+      assert_response :success
+      result = JSON.parse(response.body)
+      assert_nil result["error"], "Expected no error with cursor param"
+      assert_not_nil result["result"]["resourceTemplates"]
+    end
+
+    test "resources/templates/list returns invalid params for non-string cursor" do
+      post action_mcp.mcp_post_path,
+           params: {
+             jsonrpc: "2.0",
+             id: 44,
+             method: "resources/templates/list",
+             params: { cursor: 123 }
+           }.to_json,
+           headers: {
+             "Content-Type" => "application/json",
+             "Accept" => "application/json",
+             "Mcp-Session-Id" => @session_id
+           }
+
+      assert_response :success
+      result = JSON.parse(response.body)
+
+      assert_not_nil result["error"]
+      assert_equal(-32_602, result["error"]["code"])
+      assert_match(/Invalid cursor value/, result["error"]["message"])
+    end
+
+    test "resources/read returns MCP-compliant content shape" do
+      post action_mcp.mcp_post_path,
+           params: {
+             jsonrpc: "2.0",
+             id: 5,
+             method: "resources/read",
+             params: { uri: "ecommerce://products/1" }
+           }.to_json,
+           headers: {
+             "Content-Type" => "application/json",
+             "Accept" => "application/json",
+             "Mcp-Session-Id" => @session_id
+           }
+
+      assert_response :success
+      result = JSON.parse(response.body)
+
+      assert_nil result["error"]
+      contents = result["result"]["contents"]
+      assert_equal 1, contents.size
+
+      content = contents[0]
+      assert_equal "ecommerce://products/1", content["uri"]
+      assert_equal "application/json", content["mimeType"]
+      assert_not_nil content["text"], "Expected text field in read content"
+    end
+
+    test "resources/read returns error for unknown URI" do
+      post action_mcp.mcp_post_path,
+           params: {
+             jsonrpc: "2.0",
+             id: 6,
+             method: "resources/read",
+             params: { uri: "unknown://resource/123" }
+           }.to_json,
+           headers: {
+             "Content-Type" => "application/json",
+             "Accept" => "application/json",
+             "Mcp-Session-Id" => @session_id
+           }
+
+      assert_response :success
+      result = JSON.parse(response.body)
+
+      assert_not_nil result["error"]
+      assert_equal(-32002, result["error"]["code"])
+      assert_match(/Resource not found/, result["error"]["message"])
+    end
+  end
+end

--- a/test/mcp/resource_templates/error_handling_test.rb
+++ b/test/mcp/resource_templates/error_handling_test.rb
@@ -61,7 +61,7 @@ class ResourceTemplateErrorHandlingTest < ActiveSupport::TestCase
     response = template.call
 
     assert response.error?
-    assert_equal(-32_601, response.to_h[:code])
+    assert_equal(-32_002, response.to_h[:code])
     assert_equal "Resource not found", response.to_h[:message]
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,37 +40,8 @@ if ApplicationRecord.connection.adapter_name == "SQLite"
   end
 end
 
-class MockOrder
-  def self.find_by(id:)
-    new(id: id) if id.to_i.positive?
-  end
 
-  attr_reader :id
-
-  def initialize(id:)
-    @id = id
-  end
-
-  def to_json(*_args)
-    { id: id }.to_json
-  end
-end
-
-class MockProduct
-  def self.find_by(id:)
-    new(id: id) if id.to_i.positive?
-  end
-
-  attr_reader :id
-
-  def initialize(id:)
-    @id = id
-  end
-
-  def to_json(*_args)
-    { id: id }.to_json
-  end
-end
+# MockProduct and MockOrder are in test/dummy/app/models/
 
 module FixtureHelpers
   FIXTURE_CACHE = {}


### PR DESCRIPTION
ResourceTemplate subclasses can now override self.list(session:) to enumerate concrete resources returned by resources/list. 

This is might not the final api . i'm still experimenting ..