### PR TITLE
docs: improve documentation for abstract!, introspection, gateway, and resource testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,9 +712,11 @@ This will create:
 
 ## Authentication with Gateway
 
-ActionMCP provides a Gateway system for handling authentication. The Gateway allows you to authenticate users and make them available throughout your MCP components.
+ActionMCP provides a Gateway system for handling authentication. The Gateway allows you to authenticate users and make them available throughout your MCP components. For the full gateway reference including identifier classes, session persistence, profile switching, and production hardening tips, see **[GATEWAY.md](GATEWAY.md)**.
 
 ActionMCP uses a Gateway pattern with pluggable identifiers for authentication. You can implement custom authentication strategies using session-based auth, API keys, bearer tokens, or integrate with existing authentication systems like Warden, Devise, or external OAuth providers.
+
+> **Note:** Auth errors return HTTP 200 with a JSON-RPC error payload (not HTTP 401). This is correct per the MCP specification — all MCP communication uses JSON-RPC over HTTP, and protocol-level errors are expressed within the JSON-RPC envelope. The `initialize` request bypasses authentication per MCP spec.
 
 ### Creating an ApplicationGateway
 
@@ -1000,12 +1002,38 @@ end
 ```
 
 The TestHelper provides several assertion methods:
-- `assert_tool_findable(name)` - Verifies a tool exists and is registered
-- `assert_prompt_findable(name)` - Verifies a prompt exists and is registered
-- `execute_tool(name, **args)` - Executes a tool with arguments
-- `execute_prompt(name, **args)` - Executes a prompt with arguments
-- `assert_tool_output(result, expected)` - Asserts tool output matches expected text
-- `assert_prompt_output(result)` - Extracts and returns prompt output for assertions
+- `assert_mcp_tool_findable(name)` - Verifies a tool exists and is registered
+- `assert_mcp_prompt_findable(name)` - Verifies a prompt exists and is registered
+- `execute_mcp_tool(name, **args)` - Executes a tool with arguments and asserts success
+- `execute_mcp_tool_with_error(name, **args)` - Executes a tool without asserting success (for testing error cases)
+- `execute_mcp_prompt(name, **args)` - Executes a prompt with arguments
+- `assert_mcp_tool_output(result, expected)` - Asserts tool output matches expected content
+- `assert_mcp_prompt_output(result, expected)` - Asserts prompt output matches expected content
+- `assert_mcp_error_code(code, response)` - Asserts a specific JSON-RPC error code
+
+### Testing Resource Templates
+
+Resource templates don't have a dedicated test helper yet. Test them by instantiating and calling `resolve` directly:
+
+```ruby
+class ProductResourceTemplateTest < ActiveSupport::TestCase
+  test "resolves a product resource" do
+    product = Product.create!(name: "Widget", price: 9.99)
+    template = ProductResourceTemplate.new(id: product.id.to_s)
+
+    assert template.valid?
+    resource = template.resolve
+
+    assert_not_nil resource
+    assert_equal "application/json", resource.mime_type
+  end
+
+  test "list returns available resources" do
+    resources = ProductResourceTemplate.list
+    assert_kind_of Array, resources
+  end
+end
+```
 
 ## Inspecting Your MCP Server
 

--- a/TOOLS.MD
+++ b/TOOLS.MD
@@ -117,6 +117,33 @@ def fetch_weather_for(city)
 end
 ```
 
+## Base Classes and `abstract!`
+
+The generator creates `ApplicationMCPTool` as your base class. If you create additional intermediate base classes (e.g., for shared behavior across a group of tools), mark them with `abstract!` so they don't appear in tool listings:
+
+```ruby
+class AdminBaseTool < ApplicationMCPTool
+  abstract!
+
+  # Shared behavior for all admin tools
+  before_perform :require_admin!
+
+  private
+
+  def require_admin!
+    report_error("Admin access required") unless current_user&.admin?
+  end
+end
+
+class ManageUsersTool < AdminBaseTool
+  tool_name "manage_users"
+  description "Manage user accounts"
+  # This tool WILL appear in listings
+end
+```
+
+Without `abstract!`, your base class would register as a tool and appear in `rails action_mcp:list_tools`. The same applies to `ApplicationMCPPrompt` and `ApplicationMCPResTemplate` — the install generator already handles this for the top-level base classes, but any intermediate base classes you create need `abstract!` explicitly.
+
 ## The Core Pattern
 
 Every tool follows this pattern:
@@ -927,6 +954,22 @@ end
 5. **Validate input** when resuming from continuation
 6. **Set reasonable timeouts** to avoid hanging jobs
 7. **Log important transitions** between steps
+
+## Introspection API
+
+### `schema_property_keys`
+
+Returns an array of string keys for all defined properties on a tool class. Useful for logging, debugging, or building dynamic tool wrappers:
+
+```ruby
+CalculateSumTool.schema_property_keys
+# => ["a", "b"]
+
+FlexibleApiTool.schema_property_keys
+# => ["endpoint", "method"]
+```
+
+This is a class method available on any `ActionMCP::Tool` subclass. The result is cached and automatically invalidated when properties change.
 
 ## Security Best Practices
 


### PR DESCRIPTION
## Summary

Documentation improvements based on gaps found during migration from fast-mcp (see #189):

- **`abstract!` in TOOLS.MD**: Documents how to use `abstract!` on intermediate base classes to prevent them from appearing in tool/prompt listings
- **`schema_property_keys` in TOOLS.MD**: Documents the introspection API for retrieving defined property keys on tool classes
- **Gateway cross-linking in README**: Adds direct link to GATEWAY.md and a note about MCP-spec auth error behavior (HTTP 200 with JSON-RPC error, not HTTP 401)
- **TestHelper in README**: Updates method names to the official `assert_mcp_*` / `execute_mcp_*` API, adds `execute_mcp_tool_with_error` and `assert_mcp_error_code`
- **Resource template testing in README**: Adds a testing pattern for resource templates since there is no dedicated test helper yet

Closes #189