### PR TITLE
fix: guard against nil session when client sends unknown Mcp-Session-Id on initialize

### DIFF
--- a/app/controllers/action_mcp/application_controller.rb
+++ b/app/controllers/action_mcp/application_controller.rb
@@ -70,6 +70,11 @@ module ActionMCP
         end
       end
 
+      if session.nil?
+        id = jsonrpc_params.respond_to?(:id) ? jsonrpc_params.id : nil
+        return render_not_found("Session not found.", id)
+      end
+
       if session.new_record?
         session.save!
         response.headers[MCP_SESSION_ID_HEADER] = session.id

--- a/test/controllers/action_mcp/application_controller_test.rb
+++ b/test/controllers/action_mcp/application_controller_test.rb
@@ -307,6 +307,70 @@ module ActionMCP
       assert_equal "bad-init", error_response["id"]
     end
 
+    test "initialize with unknown Mcp-Session-Id header returns error instead of crashing" do
+      init_request = {
+        jsonrpc: "2.0",
+        id: "1",
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          clientInfo: { name: "test-client", version: "1.0.0" },
+          capabilities: {}
+        }
+      }
+
+      post "/",
+           headers: {
+             "CONTENT_TYPE" => "application/json",
+             "ACCEPT" => "application/json",
+             "Mcp-Session-Id" => "nonexistent-session-id"
+           },
+           params: init_request.to_json
+
+      assert_response :ok
+      body = response.parsed_body
+      assert_equal "1", body["id"], "Should preserve the request ID"
+      assert_not_nil body["error"], "Should return a JSON-RPC error, not crash"
+      assert_match(/session not found/i, body["error"]["message"])
+    end
+
+    test "Copilot Studio initialize with unknown session ID and unsupported protocol version" do
+      copilot_payload = {
+        jsonrpc: "2.0",
+        id: "1",
+        method: "initialize",
+        params: {
+          capabilities: {},
+          clientInfo: {
+            agentAuthenticationMode: "None",
+            agentName: "MCP2",
+            appId: "81004344-fb1a-4701-a2bd-ef33bab6bff9",
+            cdsBotId: "d340d39c-b1d9-f011-8406-7c1e523701e8",
+            channelId: "pva-studio",
+            name: "mcs",
+            version: "1.0.0"
+          },
+          protocolVersion: "2024-11-05",
+          sessionContext: {
+            "Mcp-Session-Id": "c829a212-7973-4e15-828e-7effa6b7f7f3"
+          }
+        }
+      }
+
+      post "/",
+           headers: {
+             "CONTENT_TYPE" => "application/json",
+             "ACCEPT" => "application/json",
+             "Mcp-Session-Id" => "c829a212-7973-4e15-828e-7effa6b7f7f3"
+           },
+           params: copilot_payload.to_json
+
+      assert_response :ok
+      body = response.parsed_body
+      assert_equal "1", body["id"], "Should preserve the request ID"
+      assert_not_nil body["error"], "Should return a JSON-RPC error, not crash"
+    end
+
     test "ping" do
       session = create_initialized_session
       session_id = session.id


### PR DESCRIPTION
## Description

When an MCP client sends an `initialize` request with an `Mcp-Session-Id` HTTP header that does not match any existing session, `ApplicationController#create` crashes with a `NoMethodError` because `load_session` returns `nil` and there is no nil guard.

The bug is specifically in `find_or_initialize_session`: when a session ID is present in the header, it calls `load_session` which returns `nil` for unknown IDs. The controller then calls `session.new_record?` on `nil` and crashes.

**Important**: ActionMCP's protocol version validation (`Server::Capabilities#send_capabilities`) works correctly and cleanly rejects unsupported versions with a proper JSON-RPC error. The crash only occurs when an unknown `Mcp-Session-Id` header is present, because the controller never reaches the protocol version check.

## Root Cause

`find_or_initialize_session` (application_controller.rb:175-183):

```ruby
def find_or_initialize_session
  session_id = extract_session_id                # reads Mcp-Session-Id header
  session_store = ActionMCP::Server.session_store

  if session_id
    session_store.load_session(session_id)        # returns nil for unknown IDs
  else
    session_store.create_session(nil, ...)        # always returns a valid session
  end
end
```

Then in `create` (line 73):

```ruby
session = mcp_session    # nil when load_session found nothing
if session.new_record?   # NoMethodError: undefined method 'new_record?' for nil
```

**Two paths, two outcomes:**

| Scenario | `Mcp-Session-Id` header | Code path | Result |
|----------|------------------------|-----------|--------|
| No header | absent | `create_session` -> new session -> `send_capabilities` rejects bad version | Clean JSON-RPC error |
| Unknown header | present | `load_session` -> `nil` -> `session.new_record?` | **Crash** |

## Steps to Reproduce

### Without `Mcp-Session-Id` header (PASSES)

```bash
curl -X POST http://localhost:3000/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json" \
  -d '{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"capabilities":{},"clientInfo":{"name":"test","version":"1.0"},"protocolVersion":"2024-11-05"}}'
```

Returns a proper JSON-RPC error:

```json
{
  "jsonrpc": "2.0",
  "id": "1",
  "error": {
    "code": -32602,
    "message": "Unsupported protocol version. Client requested '2024-11-05' but server supports 2025-11-25, 2025-06-18",
    "data": { "supported": ["2025-11-25", "2025-06-18"], "requested": "2024-11-05" }
  }
}
```

### With `Mcp-Session-Id` header (CRASHES)

```bash
curl -X POST http://localhost:3000/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json" \
  -H "Mcp-Session-Id: c829a212-7973-4e15-828e-7effa6b7f7f3" \
  -d '{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"capabilities":{},"clientInfo":{"name":"test","version":"1.0"},"protocolVersion":"2024-11-05"}}'
```

Server logs:

```
Unified POST Error: NoMethodError - undefined method `new_record?' for nil
app/controllers/action_mcp/application_controller.rb:73:in `create'
```

Returns a generic error with lost request ID:

```json
{
  "jsonrpc": "2.0",
  "id": null,
  "error": { "code": -32000, "message": "An unexpected error occurred." }
}
```

## Fix

Add a nil guard in `ApplicationController#create` after session resolution:

```ruby
if session.nil?
  id = jsonrpc_params.respond_to?(:id) ? jsonrpc_params.id : nil
  return render_not_found("Session not found.", id)
end
```

This is consistent with the existing nil check on line 64 (`session.nil? || session.new_record?`) which already handles this case for non-initialization requests but is skipped for `initialize` requests.

## Real-World Impact: Microsoft Copilot Studio

This bug is triggered in production by Microsoft Copilot Studio. Copilot Studio sends this `initialize` request (captured from production logs, 2026-03-20):

```json
{
  "jsonrpc": "2.0",
  "id": "1",
  "method": "initialize",
  "params": {
    "capabilities": {},
    "clientInfo": {
      "agentAuthenticationMode": "None",
      "agentName": "MCP2",
      "appId": "81004344-fb1a-4701-a2bd-ef33bab6bff9",
      "cdsBotId": "d340d39c-b1d9-f011-8406-7c1e523701e8",
      "channelId": "pva-studio",
      "name": "mcs",
      "version": "1.0.0"
    },
    "protocolVersion": "2024-11-05",
    "sessionContext": {
      "Mcp-Session-Id": "c829a212-7973-4e15-828e-7effa6b7f7f3"
    }
  }
}
```

Copilot Studio also embeds its session ID in the JSON body as `params.sessionContext.Mcp-Session-Id` and additionally sends the same value as an HTTP header, which triggers the `load_session` -> `nil` -> crash path.

### Copilot Studio compatibility notes

| Issue | Copilot Studio behavior | MCP spec / ActionMCP expectation |
|-------|------------------------|----------------------------------|
| Protocol version | Sends `"2024-11-05"` | ActionMCP supports `"2025-11-25"` and `"2025-06-18"` only |
| Session ID location | Sends in both HTTP header and JSON body (`params.sessionContext`) | Spec requires HTTP header only |
| Session ID on initialize | Sends a self-generated `Mcp-Session-Id` header on the `initialize` request | MCP spec: client must NOT send `Mcp-Session-Id` on `initialize` — the server assigns the session ID in the response |
| Stateless mode | [Recommended by community](https://simondoy.com/2025/11/18/errors-with-copilot-studio-and-mcp-are-you-stateless/) | ActionMCP has no stateless mode |

The nil guard fix resolves the crash. The protocol version mismatch is already handled correctly by `send_capabilities` once the crash is fixed.

**Why Copilot Studio sends a session ID on `initialize`:** Copilot Studio appears to pre-generate its own session IDs and expects the server to either adopt them or ignore them. This violates the MCP spec where session IDs are server-assigned, but is consistent with Microsoft's recommendation to use [stateless MCP servers](https://simondoy.com/2025/11/18/errors-with-copilot-studio-and-mcp-are-you-stateless/) where session management is effectively a no-op. Stateless mode support in ActionMCP would be a separate feature request.

### References

- [Microsoft Learn: Connect your agent to an existing MCP server](https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-add-existing-server-to-agent) (Streamable HTTP supported, SSE deprecated since Aug 2025)
- [Microsoft Learn: MCP Troubleshooting](https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-troubleshooting) (references `2024-11-05` spec in known issues)
- [Simon Doy: Errors with Copilot Studio and MCP? Are you Stateless?](https://simondoy.com/2025/11/18/errors-with-copilot-studio-and-mcp-are-you-stateless/)
- [Power Platform Community: Protocol Breach on Session Management](https://community.powerplatform.com/forums/thread/details/?threadid=f772ba63-179b-f011-b4cc-000d3a53009f)

## Test plan

- [x] New test: `initialize` with unknown `Mcp-Session-Id` header returns JSON-RPC error instead of crashing
- [x] New test: Copilot Studio payload with unknown session ID and unsupported protocol version
- [x] Verified test fails without fix (gets generic "An unexpected error occurred" from rescue block)
- [x] Verified test passes with fix (gets proper "Session not found" error with preserved request ID)
- [x] All existing controller tests still pass

## Environment where the bug was observed

- **actionmcp**: 0.104.1
- **Rails**: 8.1.2
- **Ruby**: 3.3.5
- **session_store_type**: volatile
- **Client**: Microsoft Copilot Studio (`name: "mcs"`, `version: "1.0.0"`)