### PR TITLE
fix: handle wildcard registry in register/unregister methods

### DIFF
--- a/app/models/action_mcp/session.rb
+++ b/app/models/action_mcp/session.rb
@@ -172,6 +172,7 @@ module ActionMCP
     def register_tool(tool_class_or_name)
       tool_name = normalize_name(tool_class_or_name, :tool)
       return false unless tool_exists?(tool_name)
+      return true if uses_all_tools?
 
       self.tool_registry ||= []
       unless self.tool_registry.include?(tool_name)
@@ -184,8 +185,13 @@ module ActionMCP
 
     def unregister_tool(tool_class_or_name)
       tool_name = normalize_name(tool_class_or_name, :tool)
-      self.tool_registry ||= []
 
+      if uses_all_tools?
+        return unless tool_exists?(tool_name)
+        expand_tool_registry!
+      end
+
+      self.tool_registry ||= []
       return unless self.tool_registry.delete(tool_name)
 
       save!
@@ -195,6 +201,7 @@ module ActionMCP
     def register_prompt(prompt_class_or_name)
       prompt_name = normalize_name(prompt_class_or_name, :prompt)
       return false unless prompt_exists?(prompt_name)
+      return true if uses_all_prompts?
 
       self.prompt_registry ||= []
       unless self.prompt_registry.include?(prompt_name)
@@ -207,8 +214,13 @@ module ActionMCP
 
     def unregister_prompt(prompt_class_or_name)
       prompt_name = normalize_name(prompt_class_or_name, :prompt)
-      self.prompt_registry ||= []
 
+      if uses_all_prompts?
+        return unless prompt_exists?(prompt_name)
+        expand_prompt_registry!
+      end
+
+      self.prompt_registry ||= []
       return unless self.prompt_registry.delete(prompt_name)
 
       save!
@@ -218,6 +230,7 @@ module ActionMCP
     def register_resource_template(template_class_or_name)
       template_name = normalize_name(template_class_or_name, :resource_template)
       return false unless resource_template_exists?(template_name)
+      return true if uses_all_resources?
 
       self.resource_registry ||= []
       unless self.resource_registry.include?(template_name)
@@ -230,8 +243,13 @@ module ActionMCP
 
     def unregister_resource_template(template_class_or_name)
       template_name = normalize_name(template_class_or_name, :resource_template)
-      self.resource_registry ||= []
 
+      if uses_all_resources?
+        return unless resource_template_exists?(template_name)
+        expand_resource_registry!
+      end
+
+      self.resource_registry ||= []
       return unless self.resource_registry.delete(template_name)
 
       save!
@@ -346,6 +364,20 @@ module ActionMCP
       self.tool_registry = [ "*" ]
       self.prompt_registry = [ "*" ]
       self.resource_registry = [ "*" ]
+    end
+
+    # Expand wildcard registries to explicit name lists so individual
+    # entries can be removed without breaking the wildcard check.
+    def expand_tool_registry!
+      self.tool_registry = ActionMCP.configuration.filtered_tools.map(&:name)
+    end
+
+    def expand_prompt_registry!
+      self.prompt_registry = ActionMCP.configuration.filtered_prompts.map(&:name)
+    end
+
+    def expand_resource_registry!
+      self.resource_registry = ActionMCP.configuration.filtered_resources.map(&:name)
     end
 
     def normalize_name(class_or_name, type)

--- a/test/models/action_mcp/session_test.rb
+++ b/test/models/action_mcp/session_test.rb
@@ -100,5 +100,50 @@ module ActionMCP
       # Verify instructions are not present
       refute payload.key?(:instructions)
     end
+
+    test "register_tool is a no-op on wildcard registry" do
+      session = Session.create
+      assert_equal [ "*" ], session.tool_registry
+
+      tool_count = session.registered_tools.count
+      assert tool_count > 1
+
+      session.register_tool(session.registered_tools.first.tool_name)
+      assert_equal [ "*" ], session.tool_registry
+      assert_equal tool_count, session.registered_tools.count
+    end
+
+    test "unregister_tool expands wildcard before removing" do
+      session = Session.create
+      assert_equal [ "*" ], session.tool_registry
+
+      all_tools = session.registered_tools
+      tool_to_remove = all_tools.first.tool_name
+
+      session.unregister_tool(tool_to_remove)
+      refute_includes session.tool_registry, "*"
+      refute_includes session.tool_registry, tool_to_remove
+      assert_equal all_tools.count - 1, session.registered_tools.count
+    end
+
+    test "unregister_tool preserves wildcard when tool does not exist" do
+      session = Session.create
+      assert_equal [ "*" ], session.tool_registry
+
+      session.unregister_tool("nonexistent_tool_xyz")
+      assert_equal [ "*" ], session.tool_registry
+      assert session.uses_all_tools?
+    end
+
+    test "register_tool works normally on explicit registry" do
+      session = Session.create
+      session.tool_registry = []
+      session.save!
+
+      tool_name = ActionMCP.configuration.filtered_tools.first.name
+      assert session.register_tool(tool_name)
+      assert_includes session.tool_registry, tool_name
+      assert_equal 1, session.registered_tools.count
+    end
   end
 end


### PR DESCRIPTION
found this while reading through the gateway/session code around #183 — the wildcard-to-explicit registry transition isn't handled.

calling `register_tool` on a session with the default `["*"]` wildcard registry appends to the array, turning it into `["*", "tool_name"]`. then `registered_tools` checks `== ["*"]` which fails, falls to the else branch, and `ToolsRegistry.find("*")` silently returns nil. session goes from all tools down to one.

```ruby
session = ActionMCP::Session.create!(id: SecureRandom.hex(6), protocol_version: "2025-06-18", status: "initialized")
session.registered_tools.count  # => 36
session.register_tool(session.registered_tools.first.tool_name)
session.registered_tools.count  # => 1
```

**what this does:**

- `register_tool` / `register_prompt` / `register_resource_template` short-circuit when the wildcard is active — the item is already available, no-op
- `unregister_tool` / `unregister_prompt` / `unregister_resource_template` expand the wildcard to an explicit name list before removing. skips expansion for nonexistent items to keep the wildcard intact
- 4 new tests: wildcard no-op, expansion on unregister, nonexistent tool preservation, explicit registry behavior