### PR TITLE
feat: validate enum values for properties and collections

### DIFF
--- a/lib/action_mcp/tool.rb
+++ b/lib/action_mcp/tool.rb
@@ -359,12 +359,12 @@ module ActionMCP
       end
 
       attribute prop_name, mapped_type, default: default
+      validates_with ArrayEnumValidator, prop_name:, enum: opts[:enum] if opts[:enum]
 
       # For arrays, we need to check if the attribute is nil, not if it's empty
       return unless required
 
-      validates prop_name, presence: true, allow_nil: !required, unless: -> { send(prop_name).is_a?(Array) }
-      validates_with ArrayEnumValidator, prop_name:, enum: opts[:enum] if opts[:enum]
+      validates prop_name, presence: true, unless: -> { send(prop_name).is_a?(Array) }
 
       validate do
         errors.add(prop_name, "can't be blank") if send(prop_name).nil?

--- a/lib/action_mcp/tool.rb
+++ b/lib/action_mcp/tool.rb
@@ -320,6 +320,7 @@ module ActionMCP
       # Map the JSON Schema type to an ActiveModel attribute type.
       attribute prop_name, map_json_type_to_active_model_type(type), default: default
       validates prop_name, presence: true, if: -> { required }
+      validates prop_name, inclusion: { in: opts[:enum] }, allow_nil: !required if opts[:enum]
 
       return unless %w[number integer].include?(type)
 
@@ -337,11 +338,12 @@ module ActionMCP
     # @param required [Boolean] Whether the collection is required (default: false).
     # @param default [Array, nil] The default value for the collection.
     # @return [void]
-    def self.collection(prop_name, type:, description: nil, required: false, default: [])
+    def self.collection(prop_name, type:, description: nil, required: false, default: [], **opts)
       raise ArgumentError, "Type is required for a collection" if type.nil?
 
       collection_definition = { type: "array", items: { type: type } }
       collection_definition[:description] = description if description && !description.empty?
+      collection_definition.merge!(opts) if opts.any?
 
       self._schema_properties = _schema_properties.merge(prop_name.to_s => collection_definition)
       new_required = _required_properties.dup
@@ -360,7 +362,9 @@ module ActionMCP
       # For arrays, we need to check if the attribute is nil, not if it's empty
       return unless required
 
-      validates prop_name, presence: true, unless: -> { send(prop_name).is_a?(Array) }
+      validates prop_name, presence: true, allow_nil: !required, unless: -> { send(prop_name).is_a?(Array) }
+      validates_with ArrayEnumValidator, prop_name:, enum: opts[:enum] if opts[:enum]
+
       validate do
         errors.add(prop_name, "can't be blank") if send(prop_name).nil?
       end

--- a/lib/action_mcp/tool.rb
+++ b/lib/action_mcp/tool.rb
@@ -341,9 +341,10 @@ module ActionMCP
     def self.collection(prop_name, type:, description: nil, required: false, default: [], **opts)
       raise ArgumentError, "Type is required for a collection" if type.nil?
 
-      collection_definition = { type: "array", items: { type: type } }
+      items_definition = { type: type }
+      items_definition[:enum] = opts[:enum] if opts[:enum]
+      collection_definition = { type: "array", items: items_definition }
       collection_definition[:description] = description if description && !description.empty?
-      collection_definition.merge!(opts) if opts.any?
 
       self._schema_properties = _schema_properties.merge(prop_name.to_s => collection_definition)
       new_required = _required_properties.dup

--- a/lib/action_mcp/tool/array_enum_validator.rb
+++ b/lib/action_mcp/tool/array_enum_validator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ActionMCP::Tool::ArrayEnumValidator < ActiveModel::Validator
+  def validate(record)
+    invalid_values = record.send(options[:prop_name]) - options[:enum]
+
+    return if invalid_values.empty?
+
+    record.errors.add(options[:prop_name], "contains invalid value(s) #{invalid_values.inspect}, allowed values are: #{options[:enum].inspect}")
+  end
+end

--- a/lib/action_mcp/tool/array_enum_validator.rb
+++ b/lib/action_mcp/tool/array_enum_validator.rb
@@ -2,8 +2,10 @@
 
 class ActionMCP::Tool::ArrayEnumValidator < ActiveModel::Validator
   def validate(record)
-    invalid_values = record.send(options[:prop_name]) - options[:enum]
+    values = record.send(options[:prop_name])
+    return if values.nil? || !values.is_a?(Array)
 
+    invalid_values = values - options[:enum]
     return if invalid_values.empty?
 
     record.errors.add(options[:prop_name], "contains invalid value(s) #{invalid_values.inspect}, allowed values are: #{options[:enum].inspect}")

--- a/test/dummy/app/mcp/tools/enum_array_tool.rb
+++ b/test/dummy/app/mcp/tools/enum_array_tool.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class EnumArrayTool < ApplicationMCPTool
+  title "Enum Array Tool"
+  description "accepts array_string attribute"
+  read_only
+  idempotent
+  collection :fruits, type: "string", required: true, enum: [ "apple", "banana", "cherry" ], description: "An array of fruits"
+
+  def perform
+    render text: fruits.join(", ")
+  end
+end

--- a/test/dummy/app/mcp/tools/enum_tool.rb
+++ b/test/dummy/app/mcp/tools/enum_tool.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class EnumTool < ApplicationMCPTool
+  title "Enum Tool"
+  description "accepts enum attribute"
+  read_only
+  idempotent
+  property :fruit, type: "string", required: true, enum: [ "apple", "banana", "cherry" ], description: "A fruit"
+
+  def perform
+    render text: fruit
+  end
+end

--- a/test/tools/enum_array_tool_test.rb
+++ b/test/tools/enum_array_tool_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EnumArrayToolTest < ActiveSupport::TestCase
+  include ActionMCP::TestHelper
+
+  setup do
+    @tool = EnumArrayTool.new
+  end
+
+  test "tool is registered and available" do
+    assert ActionMCP.tools.key?("enum_array")
+    assert_equal EnumArrayTool, ActionMCP.tools["enum_array"]
+  end
+
+  test "tool metadata is correct" do
+    assert_equal "Enum Array Tool", EnumArrayTool.title
+    assert_equal "accepts array_string attribute", EnumArrayTool.description
+    assert EnumArrayTool.read_only?
+    assert EnumArrayTool.idempotent?
+  end
+
+  test "schema generation for enum array" do
+    schema = EnumArrayTool.to_h[:inputSchema]
+
+    assert_not_nil schema
+    assert_equal "object", schema[:type]
+
+    # Check fruits property
+    fruits_prop = schema[:properties]["fruits"] || schema[:properties][:fruits]
+    assert_not_nil fruits_prop
+    assert_equal "array", fruits_prop["type"] || fruits_prop[:type]
+
+    # Check items schema
+    items = fruits_prop["items"] || fruits_prop[:items]
+    assert_not_nil items
+    assert_equal "string", items["type"] || items[:type]
+
+    # Check required
+    required = schema[:required] || schema["required"]
+    assert required
+
+    # Check enum values
+    enum_values = schema[:properties]["fruits"][:enum]
+    assert_equal [ "apple", "banana", "cherry" ], enum_values
+  end
+
+  test "accepts array of fruits" do
+    @tool.fruits = [ "apple", "banana", "cherry" ]
+    assert @tool.valid?
+    assert_equal [ "apple", "banana", "cherry" ], @tool.fruits
+  end
+
+  test "rejects invalid fruit values" do
+    @tool.fruits = [ "apple", "orange", "banana" ]
+    assert_not @tool.valid?
+    assert_includes @tool.errors[:fruits], 'contains invalid value(s) ["orange"], allowed values are: ["apple", "banana", "cherry"]'
+  end
+
+  test "handles nil input" do
+    @tool.fruits = nil
+    # Since we cast nil to [], this should be valid
+    assert @tool.valid?
+    assert_equal [], @tool.fruits
+  end
+
+  test "handles empty array" do
+    @tool.fruits = []
+    # Empty array should be valid - presence validation allows empty arrays
+    assert @tool.valid?
+    assert_equal [], @tool.fruits
+  end
+
+  test "requires fruits array" do
+    # Don't set fruits at all - it should use the default empty array
+    # The tool was initialized in setup, so fruits should be []
+    assert @tool.valid?
+    assert_equal [], @tool.fruits
+  end
+
+  test "perform concatenation correctly" do
+    @tool.fruits = [ "apple", "banana", "cherry" ]
+    result = @tool.call
+    assert_not result.is_error
+    assert_equal "apple, banana, cherry", result.contents.first.text
+  end
+
+  test "call method works correctly" do
+    result = EnumArrayTool.call(fruits: [ "apple", "banana", "cherry" ])
+    assert_not result.is_error
+    assert_equal "apple, banana, cherry", result.contents.first.text
+  end
+
+  test "call with empty arguments uses default" do
+    result = EnumArrayTool.call({})
+    # Should use default empty array and return empty string
+    assert_not result.is_error
+    assert_equal "", result.contents.first.text
+  end
+
+  test "integration with JSON parsing" do
+    # Simulate JSON input
+    json_input = { "fruits" => [ "apple", "banana", "cherry" ] }
+    @tool.assign_attributes(json_input)
+
+    assert @tool.valid?
+    assert_equal [ "apple", "banana", "cherry" ], @tool.fruits
+
+    result = @tool.call
+    assert_equal "apple, banana, cherry", result.contents.first.text
+  end
+
+  test "works with MCP execution" do
+    # Use the test helper to execute the tool
+    result = execute_mcp_tool("enum_array", fruits: [ "apple", "banana", "cherry" ])
+    assert_not result.is_error
+    assert_equal "apple, banana, cherry", result.contents.first.text
+  end
+end

--- a/test/tools/enum_array_tool_test.rb
+++ b/test/tools/enum_array_tool_test.rb
@@ -41,8 +41,8 @@ class EnumArrayToolTest < ActiveSupport::TestCase
     required = schema[:required] || schema["required"]
     assert required
 
-    # Check enum values
-    enum_values = schema[:properties]["fruits"][:enum]
+    # Check enum values are on items, not on the array itself
+    enum_values = items[:enum] || items["enum"]
     assert_equal [ "apple", "banana", "cherry" ], enum_values
   end
 

--- a/test/tools/enum_array_tool_test.rb
+++ b/test/tools/enum_array_tool_test.rb
@@ -117,4 +117,24 @@ class EnumArrayToolTest < ActiveSupport::TestCase
     assert_not result.is_error
     assert_equal "apple, banana, cherry", result.contents.first.text
   end
+
+  test "non-required collection still validates enum" do
+    tool_class = Class.new(ApplicationMCPTool) do
+      tool_name "optional_enum_array"
+      description "optional enum array"
+      collection :tags, type: "string", enum: [ "red", "green", "blue" ]
+
+      def perform
+        render text: tags.join(", ")
+      end
+    end
+
+    tool = tool_class.new
+    tool.tags = [ "red", "yellow" ]
+    assert_not tool.valid?
+    assert tool.errors[:tags].any? { |e| e.include?("yellow") }
+
+    tool.tags = [ "red", "green" ]
+    assert tool.valid?
+  end
 end

--- a/test/tools/enum_tool_test.rb
+++ b/test/tools/enum_tool_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EnumToolTest < ActiveSupport::TestCase
+  include ActionMCP::TestHelper
+
+  setup do
+    @tool = EnumTool.new
+  end
+
+  test "tool is registered and available" do
+    assert ActionMCP.tools.key?("enum")
+    assert_equal EnumTool, ActionMCP.tools["enum"]
+  end
+
+  test "tool metadata is correct" do
+    assert_equal "Enum Tool", EnumTool.title
+    assert_equal "accepts enum attribute", EnumTool.description
+    assert EnumTool.read_only?
+    assert EnumTool.idempotent?
+  end
+
+  test "schema generation for enum array" do
+    schema = EnumTool.to_h[:inputSchema]
+
+    assert_not_nil schema
+    assert_equal "object", schema[:type]
+
+    # Check fruit property
+    fruit_prop = schema[:properties]["fruit"] || schema[:properties][:fruit]
+    assert_not_nil fruit_prop
+    assert_equal "string", fruit_prop["type"] || fruit_prop[:type]
+    assert_equal [ "apple", "banana", "cherry" ], fruit_prop["enum"] || fruit_prop[:enum]
+
+    # Check required
+    required = schema[:required] || schema["required"]
+    assert_includes required, "fruit"
+  end
+
+  test "rejects invalid fruit values" do
+    @tool.fruit = "orange"
+    assert_not @tool.valid?
+    assert_includes @tool.errors[:fruit], "is not included in the list"
+  end
+
+  test "handles nil input" do
+    @tool.fruit = nil
+    # Since FloatArrayType casts nil to [], this should be valid
+    assert_not @tool.valid?
+    assert_nil @tool.fruit
+  end
+
+  test "call method works correctly" do
+    result = EnumTool.call(fruit: "apple")
+    assert_not result.is_error
+    assert_equal "apple", result.contents.first.text
+  end
+
+  test "integration with JSON parsing" do
+    # Simulate JSON input
+    json_input = { "fruit" => "apple" }
+    @tool.assign_attributes(json_input)
+
+    assert @tool.valid?
+    assert_equal "apple", @tool.fruit
+
+    result = @tool.call
+    assert_equal "apple", result.contents.first.text
+  end
+
+  test "works with MCP execution" do
+    # Use the test helper to execute the tool
+    result = execute_mcp_tool("enum", fruit: "apple")
+    assert_not result.is_error
+    assert_equal "apple", result.contents.first.text
+  end
+end

--- a/test/tools/enum_tool_test.rb
+++ b/test/tools/enum_tool_test.rb
@@ -46,7 +46,6 @@ class EnumToolTest < ActiveSupport::TestCase
 
   test "handles nil input" do
     @tool.fruit = nil
-    # Since FloatArrayType casts nil to [], this should be valid
     assert_not @tool.valid?
     assert_nil @tool.fruit
   end


### PR DESCRIPTION
rebased and fixed version of #184 by @dark-panda.

adds enum validation for `property` and `collection` DSL on tools. properties use ActiveModel `inclusion` validation, collections use a custom `ArrayEnumValidator` that checks each item.

**fix from the original**: `collection_definition.merge!(opts)` was putting `enum` at the array level in the JSON Schema output. in JSON Schema, enum on an array means the entire value must be one of the listed values — not that each item should be. moved it to `items` where it belongs:

```ruby
# before (wrong — enum on array level)
{ type: "array", items: { type: "string" }, enum: ["apple", "banana", "cherry"] }

# after (correct — enum on items)
{ type: "array", items: { type: "string", enum: ["apple", "banana", "cherry"] } }
```

also added nil guard in `ArrayEnumValidator` and cleaned up a stale comment.