### PR TITLE
feat: implement spec-compliant cursor pagination for all list endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Call it as a task from a client by adding `_meta.task` (creates a Task record an
 }
 ```
 
-Poll task status with `tasks/get` or fetch the result when finished with `tasks/result`. Use `tasks/cancel` to stop non-terminal tasks.
+Poll task status with `tasks/get` or fetch the result when finished with `tasks/result`. Use `tasks/cancel` to stop non-terminal tasks. `tasks/list` returns tasks in recent-first order and always paginates (default 50 per page, or `pagination_page_size` if configured). The response includes an opaque `nextCursor` when more results are available — treat cursors as opaque tokens.
 
 ### ActionMCP::ResourceTemplate
 
@@ -490,6 +490,25 @@ end
 ```
 
 For dynamic versioning, consider adding the `rails_app_version` gem.
+
+### Pagination
+
+All list endpoints (`tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`) support cursor-based pagination per the MCP specification. Pagination is **off by default** — set `pagination_page_size` to enable:
+
+```ruby
+config.action_mcp.pagination_page_size = 10
+```
+
+Or in `config/mcp.yml`:
+
+```yaml
+shared:
+  pagination_page_size: 10
+```
+
+When set, responses include an opaque `nextCursor` when more items are available. When `nil` (default), all items are returned in a single response. Enable only when your clients support cursor-based pagination.
+
+`tasks/list` always paginates regardless of this setting (defaults to 50 per page, or `pagination_page_size` if configured).
 
 ### Server Instructions
 

--- a/RESOURCE_TEMPLATES.md
+++ b/RESOURCE_TEMPLATES.md
@@ -145,13 +145,23 @@ Fields `description` and `mime_type` fall back to the template's values if not p
 
 ### Cursor Pagination
 
-Both `resources/list` and `resources/templates/list` support cursor-based pagination:
+All list endpoints (`resources/list`, `resources/templates/list`, `tools/list`, `prompts/list`) support cursor-based pagination per the MCP specification.
 
-```json
-{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{"cursor":"MTA="}}
+Pagination is **opt-in** — set `pagination_page_size` in your configuration to enable it:
+
+```ruby
+config.action_mcp.pagination_page_size = 10
 ```
 
-The response includes `nextCursor` when more results are available.
+When enabled, responses include a `nextCursor` when more results are available. Clients should pass this cursor back to fetch the next page:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{"cursor":"MTA"}}
+```
+
+When `pagination_page_size` is `nil` (the default), all items are returned in a single response. Enable only when your clients support cursor-based pagination.
+
+Tasks (`tasks/list`) always paginate regardless of this setting since they are database-backed and can grow unbounded.
 
 ## Read Contract (`resources/read`)
 

--- a/The_Hitchhikers_Guide_to_MCP.md
+++ b/The_Hitchhikers_Guide_to_MCP.md
@@ -185,7 +185,7 @@ Born from the frustration of LLMs timing out on long-running tasks, 2025-11-25 l
 - **New RPC Methods:**
   - `tasks/get` - Check on your task's status (like asking "are we there yet?")
   - `tasks/result` - Get the final output (blocks until terminal state)
-  - `tasks/list` - See all your tasks (with pagination, because we're civilized)
+  - `tasks/list` - See all your tasks, newest first, with opaque cursor pagination
   - `tasks/cancel` - Give up on a task (we've all been there)
 - **Status Notifications:** `notifications/tasks/status` broadcasts state changes (no more polling every 100ms)
 
@@ -320,6 +320,7 @@ Born from the frustration of LLMs timing out on long-running tasks, 2025-11-25 l
 - **Database:** Tasks stored in `action_mcp_session_tasks` table
 - **TTL:** Configurable expiration for automatic cleanup
 - **Notifications:** Status updates via `notifications/tasks/status`
+- **Task Listing:** `tasks/list` follows recent ordering (`created_at DESC, id DESC`) so page boundaries stay stable
 
 ### **Transport Layer:**
 - **HTTP/HTTPS Only:** No STDIO, ever

--- a/app/models/action_mcp/session/task.rb
+++ b/app/models/action_mcp/session/task.rb
@@ -68,7 +68,15 @@ module ActionMCP
       # Scopes - state_machines >= 0.100.0 auto-generates .with_status(:state) scopes
       scope :terminal, -> { with_status(:completed, :failed, :cancelled) }
       scope :non_terminal, -> { with_status(:working, :input_required) }
-      scope :recent, -> { order(created_at: :desc) }
+      scope :recent, -> { order(created_at: :desc, id: :desc) }
+      scope :before_recent, lambda { |task|
+        table = arel_table
+
+        where(
+          table[:created_at].lt(task.created_at)
+            .or(table[:created_at].eq(task.created_at).and(table[:id].lt(task.id)))
+        )
+      }
 
       # State machine definition per MCP spec
       state_machine :status, initial: :working do

--- a/lib/action_mcp/configuration.rb
+++ b/lib/action_mcp/configuration.rb
@@ -73,6 +73,10 @@ module ActionMCP
       @tasks_list_enabled = true
       @tasks_cancel_enabled = true
 
+      # Pagination - nil means off. Set a number to enable with that page size.
+      # Most MCP clients (including Claude Code) don't follow nextCursor yet.
+      @pagination_page_size = nil
+
       # Schema validation - disabled by default for backward compatibility
       @validate_structured_content = false
 
@@ -130,6 +134,19 @@ module ActionMCP
 
     def allowed_identity_keys=(value)
       @allowed_identity_keys = Array(value).map(&:to_s).freeze
+    end
+
+    # Pagination page size. nil = pagination disabled, positive integer = enabled.
+    attr_reader :pagination_page_size
+
+    def pagination_page_size=(value)
+      if value.nil?
+        @pagination_page_size = nil
+      else
+        size = value.to_i
+        raise ArgumentError, "pagination_page_size must be a positive integer, got: #{value.inspect}" unless size > 0
+        @pagination_page_size = size
+      end
     end
 
     def gateway_class
@@ -382,6 +399,11 @@ module ActionMCP
       # Extract server instructions
       if config["server_instructions"]
         @server_instructions = parse_instructions(config["server_instructions"])
+      end
+
+      # Extract pagination page size (nil = off, positive integer = on)
+      if config.key?("pagination_page_size")
+        self.pagination_page_size = config["pagination_page_size"]
       end
     end
 

--- a/lib/action_mcp/server/handlers/prompt_handler.rb
+++ b/lib/action_mcp/server/handlers/prompt_handler.rb
@@ -35,8 +35,8 @@ module ActionMCP
           transport.send_prompts_get(id, name, arguments)
         end
 
-        def handle_prompts_list(id, _params)
-          transport.send_prompts_list(id)
+        def handle_prompts_list(id, params)
+          transport.send_prompts_list(id, params)
         end
 
         def extract_name(params)

--- a/lib/action_mcp/server/pagination.rb
+++ b/lib/action_mcp/server/pagination.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module ActionMCP
+  module Server
+    # Shared cursor-based pagination for all list endpoints.
+    #
+    # Two strategies:
+    #   1. Offset-based — for in-memory arrays (tools, prompts, resource templates).
+    #   2. Keyset-based — for ActiveRecord relations (tasks). Stable under concurrent writes.
+    #
+    # When pagination_page_size is nil (default), returns all items
+    # unless the caller passes force: true or the client sends a cursor.
+    module Pagination
+      DEFAULT_PAGE_SIZE = 10
+
+      # Offset-based pagination for in-memory collections (tools, prompts, resources).
+      # For ActiveRecord relations, use paginate_by_keyset instead.
+      #
+      # @param collection [Array] Items to paginate
+      # @param cursor [String, nil] Opaque cursor from the client
+      # @param page_size [Integer, nil] Override page size (nil = use config)
+      # @param force [Boolean] Force pagination even when globally disabled
+      # @return [Array(Array, String|nil)] [page_items, next_cursor_or_nil]
+      def paginate(collection, cursor: nil, page_size: nil, force: false)
+        effective_page_size = page_size || pagination_page_size
+        items = Array(collection)
+
+        return [ items, nil ] unless force || effective_page_size || cursor
+
+        page_size = effective_page_size || DEFAULT_PAGE_SIZE
+        offset = decode_offset_cursor(cursor)
+        page = items.drop(offset).take(page_size + 1)
+
+        has_more = page.size > page_size
+        page = page.first(page_size) if has_more
+        next_cursor = has_more ? encode_offset_cursor(offset + page_size) : nil
+
+        [ page, next_cursor ]
+      end
+
+      # Keyset-based pagination for ActiveRecord relations.
+      # Uses a single column as cursor (must be unique + ordered).
+      # The relation MUST already be ordered by that column.
+      #
+      # @param relation [ActiveRecord::Relation] Ordered AR relation
+      # @param cursor [String, nil] Opaque keyset cursor (Base64-encoded column value)
+      # @param page_size [Integer] Page size
+      # @param column [Symbol] Column to use as cursor key (default: :id)
+      # @return [Array(Array, String|nil)] [page_items, next_cursor_or_nil]
+      def paginate_by_keyset(relation, cursor: nil, page_size: DEFAULT_PAGE_SIZE, column: :id)
+        if cursor
+          value = decode_keyset_cursor(cursor)
+          relation = relation.where(column => ...value)
+        end
+
+        page = relation.limit(page_size + 1).to_a
+        has_more = page.size > page_size
+        items = has_more ? page.first(page_size) : page
+        next_cursor = has_more ? encode_keyset_cursor(items.last, column) : nil
+
+        [ items, next_cursor ]
+      end
+
+      private
+
+      def pagination_page_size
+        ActionMCP.configuration.pagination_page_size
+      end
+
+      # --- Offset cursors (in-memory arrays) ---
+
+      def decode_offset_cursor(cursor)
+        return 0 if cursor.nil?
+        raise CursorError, "Cursor must be a non-empty string" unless cursor.is_a?(String) && !cursor.empty?
+
+        decoded = Base64.urlsafe_decode64(cursor)
+        raise CursorError, "Invalid cursor format" unless decoded.match?(/\A\d+\z/)
+        decoded.to_i
+      rescue ArgumentError
+        raise CursorError, "Invalid cursor encoding"
+      end
+
+      def encode_offset_cursor(offset)
+        Base64.urlsafe_encode64(offset.to_s, padding: false)
+      end
+
+      # --- Keyset cursors (ActiveRecord) ---
+
+      def decode_keyset_cursor(cursor)
+        raise CursorError, "Cursor must be a non-empty string" unless cursor.is_a?(String) && !cursor.empty?
+        Base64.urlsafe_decode64(cursor)
+      rescue ArgumentError
+        raise CursorError, "Invalid cursor encoding"
+      end
+
+      def encode_keyset_cursor(record, column)
+        value = record.public_send(column)
+        Base64.urlsafe_encode64(value.to_s, padding: false)
+      end
+    end
+
+    # Raised when a client provides a malformed cursor.
+    # Handlers catch this and return -32602 (Invalid params).
+    class CursorError < StandardError; end
+  end
+end

--- a/lib/action_mcp/server/prompts.rb
+++ b/lib/action_mcp/server/prompts.rb
@@ -3,10 +3,15 @@
 module ActionMCP
   module Server
     module Prompts
-      def send_prompts_list(request_id)
-        # Use session's registered prompts
-        prompts = session.registered_prompts.map(&:to_h)
-        send_jsonrpc_response(request_id, result: { prompts: prompts })
+      def send_prompts_list(request_id, params = {})
+        page, next_cursor = paginate(session.registered_prompts, cursor: params["cursor"])
+
+        result = { prompts: page.map(&:to_h) }
+        result[:nextCursor] = next_cursor if next_cursor
+
+        send_jsonrpc_response(request_id, result: result)
+      rescue Server::CursorError => e
+        send_jsonrpc_error(request_id, :invalid_params, e.message)
       end
 
       def send_prompts_get(request_id, prompt_name, params)

--- a/lib/action_mcp/server/resources.rb
+++ b/lib/action_mcp/server/resources.rb
@@ -3,73 +3,23 @@
 module ActionMCP
   module Server
     module Resources
-      # Default page size for cursor-based pagination
-      RESOURCES_PAGE_SIZE = 100
-
       # Send list of concrete resources to the client.
       # Aggregates resources from templates that implement self.list.
       #
       # @param request_id [String, Integer] The ID of the request to respond to
       # @param params [Hash] Optional params including "cursor" for pagination
       def send_resources_list(request_id, params = {})
-        templates = session.registered_resource_templates
+        all_resources = collect_resources(request_id)
+        return unless all_resources # nil means an error was already sent
 
-        # Collect resources from templates that implement list
-        all_resources = []
-        seen_uris = {}
+        page, next_cursor = paginate(all_resources, cursor: params["cursor"])
 
-        templates.each do |template_class|
-          next unless template_class.lists_resources?
+        result = { resources: page.map(&:to_h) }
+        result[:nextCursor] = next_cursor if next_cursor
 
-          begin
-            listed = template_class.list(session: session)
-          rescue StandardError => e
-            Rails.logger.error "[MCP] Error listing resources from #{template_class.name}: #{e.message}"
-            next
-          end
-
-          unless listed.is_a?(Array)
-            Rails.logger.warn "[MCP] #{template_class.name}.list returned #{listed.class}, expected Array; skipping"
-            next
-          end
-
-          listed.each do |resource|
-            unless resource.is_a?(ActionMCP::Resource)
-              Rails.logger.warn "[MCP] #{template_class.name}.list returned non-Resource: #{resource.class}"
-              next
-            end
-
-            # Validate the listed URI is readable by the declaring template
-            unless template_class.readable_uri?(resource.uri)
-              Rails.logger.warn "[MCP] #{template_class.name}.list returned URI not readable by its own template: #{resource.uri}"
-              next
-            end
-
-            # Deduplicate by URI
-            if (existing = seen_uris[resource.uri])
-              if existing == resource
-                # Identical duplicate, skip silently
-                next
-              else
-                # Conflicting metadata for same URI
-                send_jsonrpc_error(request_id, :invalid_params,
-                  "Resource URI collision: '#{resource.uri}' listed by multiple templates with conflicting metadata")
-                return
-              end
-            end
-
-            seen_uris[resource.uri] = resource
-            all_resources << resource
-          end
-        end
-
-        # Apply cursor-based pagination
-        result = paginate_resources(all_resources, params["cursor"])
-        if result == :invalid_cursor
-          send_jsonrpc_error(request_id, :invalid_params, "Invalid cursor value")
-          return
-        end
         send_jsonrpc_response(request_id, result: result)
+      rescue Server::CursorError => e
+        send_jsonrpc_error(request_id, :invalid_params, e.message)
       end
 
       # Send list of resource templates to the client
@@ -80,13 +30,14 @@ module ActionMCP
         templates = session.registered_resource_templates.map(&:to_h)
         log_resource_templates
 
-        # Apply cursor-based pagination
-        result = paginate_templates(templates, params["cursor"])
-        if result == :invalid_cursor
-          send_jsonrpc_error(request_id, :invalid_params, "Invalid cursor value")
-          return
-        end
+        page, next_cursor = paginate(templates, cursor: params["cursor"])
+
+        result = { resourceTemplates: page }
+        result[:nextCursor] = next_cursor if next_cursor
+
         send_jsonrpc_response(request_id, result: result)
+      rescue Server::CursorError => e
+        send_jsonrpc_error(request_id, :invalid_params, e.message)
       end
 
       # Read and return the contents of a resource
@@ -159,6 +110,57 @@ module ActionMCP
 
       private
 
+      # Collect all concrete resources from templates that implement list.
+      # Returns nil if a URI collision error was sent.
+      # @return [Array<ActionMCP::Resource>, nil]
+      def collect_resources(request_id)
+        all_resources = []
+        seen_uris = {}
+
+        session.registered_resource_templates.each do |template_class|
+          next unless template_class.lists_resources?
+
+          begin
+            listed = template_class.list(session: session)
+          rescue StandardError => e
+            Rails.logger.error "[MCP] Error listing resources from #{template_class.name}: #{e.message}"
+            next
+          end
+
+          unless listed.is_a?(Array)
+            Rails.logger.warn "[MCP] #{template_class.name}.list returned #{listed.class}, expected Array; skipping"
+            next
+          end
+
+          listed.each do |resource|
+            unless resource.is_a?(ActionMCP::Resource)
+              Rails.logger.warn "[MCP] #{template_class.name}.list returned non-Resource: #{resource.class}"
+              next
+            end
+
+            unless template_class.readable_uri?(resource.uri)
+              Rails.logger.warn "[MCP] #{template_class.name}.list returned URI not readable by its own template: #{resource.uri}"
+              next
+            end
+
+            if (existing = seen_uris[resource.uri])
+              if existing == resource
+                next
+              else
+                send_jsonrpc_error(request_id, :invalid_params,
+                  "Resource URI collision: '#{resource.uri}' listed by multiple templates with conflicting metadata")
+                return nil
+              end
+            end
+
+            seen_uris[resource.uri] = resource
+            all_resources << resource
+          end
+        end
+
+        all_resources
+      end
+
       # Normalize a content object to MCP ReadResourceResult content shape.
       #
       # @return [Hash] with keys: uri, mimeType, and text or blob
@@ -172,67 +174,6 @@ module ActionMCP
         else
           content.respond_to?(:to_h) ? content.to_h : content
         end
-      end
-
-      # Paginate a list of resources with cursor support.
-      #
-      # @param resources [Array<ActionMCP::Resource>] All resources
-      # @param cursor [String, nil] Base64-encoded offset cursor
-      # @return [Hash] Result hash with :resources and optional :nextCursor
-      def paginate_resources(resources, cursor)
-        offset = decode_cursor(cursor)
-        return :invalid_cursor if offset == :invalid
-
-        page = resources[offset, RESOURCES_PAGE_SIZE] || []
-
-        result = { resources: page.map(&:to_h) }
-
-        next_offset = offset + RESOURCES_PAGE_SIZE
-        if next_offset < resources.size
-          result[:nextCursor] = encode_cursor(next_offset)
-        end
-
-        result
-      end
-
-      # Paginate a list of templates with cursor support.
-      #
-      # @param templates [Array<Hash>] All template hashes
-      # @param cursor [String, nil] Base64-encoded offset cursor
-      # @return [Hash] Result hash with :resourceTemplates and optional :nextCursor
-      def paginate_templates(templates, cursor)
-        offset = decode_cursor(cursor)
-        return :invalid_cursor if offset == :invalid
-
-        page = templates[offset, RESOURCES_PAGE_SIZE] || []
-
-        result = { resourceTemplates: page }
-
-        next_offset = offset + RESOURCES_PAGE_SIZE
-        if next_offset < templates.size
-          result[:nextCursor] = encode_cursor(next_offset)
-        end
-
-        result
-      end
-
-      # Decode a cursor string to a non-negative integer offset.
-      # Returns 0 for nil cursors, :invalid for malformed/negative/non-string values.
-      def decode_cursor(cursor)
-        return 0 if cursor.nil?
-        return :invalid unless cursor.is_a?(String) && !cursor.empty?
-
-        decoded = Base64.strict_decode64(cursor)
-        return :invalid unless decoded.match?(/\A\d+\z/)
-
-        decoded.to_i
-      rescue ArgumentError
-        :invalid
-      end
-
-      # Encode an integer offset as a cursor string.
-      def encode_cursor(offset)
-        Base64.strict_encode64(offset.to_s)
       end
 
       # Log all registered resource templates

--- a/lib/action_mcp/server/tasks.rb
+++ b/lib/action_mcp/server/tasks.rb
@@ -37,25 +37,21 @@ module ActionMCP
         send_jsonrpc_response(request_id, result: task.to_task_result)
       end
 
-      # List tasks for the session with optional pagination
+      # List tasks for the session with keyset pagination.
+      # Tasks always paginate (AR-backed, can grow unbounded).
+      # Cursor is the last task id from the previous page. We resolve it
+      # through AR so the boundary matches the recent scope exactly.
       # @param request_id [String, Integer] JSON-RPC request ID
       # @param cursor [String, nil] Pagination cursor
       def send_tasks_list(request_id, cursor: nil)
-        # Parse cursor if provided
-        offset = cursor.to_i if cursor.present?
-        offset ||= 0
-        limit = 50
+        page, next_cursor = paginate_tasks_by_recent(cursor: cursor, page_size: pagination_page_size || 50)
 
-        tasks = session.tasks.recent.offset(offset).limit(limit + 1)
-        has_more = tasks.length > limit
-        tasks = tasks.first(limit)
-
-        result = {
-          tasks: tasks.map(&:to_task_data)
-        }
-        result[:nextCursor] = (offset + limit).to_s if has_more
+        result = { tasks: page.map(&:to_task_data) }
+        result[:nextCursor] = next_cursor if next_cursor
 
         send_jsonrpc_response(request_id, result: result)
+      rescue Server::CursorError => e
+        send_jsonrpc_error(request_id, :invalid_params, e.message)
       end
 
       # Cancel a task
@@ -118,6 +114,30 @@ module ActionMCP
           # Note: we need the request_id to send error, but this is called from handler
           # The handler should handle the nil return
         end
+        task
+      end
+
+      def paginate_tasks_by_recent(cursor:, page_size:)
+        relation = session.tasks.recent
+
+        if cursor
+          cursor_task = find_task_cursor(cursor)
+          relation = relation.before_recent(cursor_task)
+        end
+
+        page = relation.limit(page_size + 1).to_a
+        has_more = page.size > page_size
+        items = has_more ? page.first(page_size) : page
+        next_cursor = has_more ? encode_keyset_cursor(items.last, :id) : nil
+
+        [ items, next_cursor ]
+      end
+
+      def find_task_cursor(cursor)
+        task_id = decode_keyset_cursor(cursor)
+        task = session.tasks.select(:id, :created_at).find_by(id: task_id)
+        raise Server::CursorError, "Invalid cursor" unless task
+
         task
       end
     end

--- a/lib/action_mcp/server/tools.rb
+++ b/lib/action_mcp/server/tools.rb
@@ -5,35 +5,24 @@ module ActionMCP
     module Tools
       def send_tools_list(request_id, params = {})
         protocol_version = session.protocol_version
-        # Extract progress token from _meta if provided
         progress_token = params.dig("_meta", "progressToken")
 
-        # Send initial progress notification if token is provided
         if progress_token
-          send_progress_notification(
-            progressToken: progress_token,
-            progress: 0,
-            message: "Starting tools list retrieval"
-          )
+          send_progress_notification(progressToken: progress_token, progress: 0, message: "Starting tools list retrieval")
         end
 
-        # Use session's registered tools instead of global registry
-        registered_tools = session.registered_tools
+        page, next_cursor = paginate(session.registered_tools, cursor: params["cursor"])
 
-        tools = registered_tools.map do |tool_class|
-          tool_class.to_h(protocol_version: protocol_version)
-        end
+        result = { tools: page.map { |t| t.to_h(protocol_version: protocol_version) } }
+        result[:nextCursor] = next_cursor if next_cursor
 
-        # Send completion progress notification if token is provided
         if progress_token
-          send_progress_notification(
-            progressToken: progress_token,
-            progress: 100,
-            message: "Tools list retrieval complete"
-          )
+          send_progress_notification(progressToken: progress_token, progress: 100, message: "Tools list retrieval complete")
         end
 
-        send_jsonrpc_response(request_id, result: { tools: tools })
+        send_jsonrpc_response(request_id, result: result)
+      rescue Server::CursorError => e
+        send_jsonrpc_error(request_id, :invalid_params, e.message)
       end
 
       def send_tools_call(request_id, tool_name, arguments, _meta = {})

--- a/lib/action_mcp/server/transport_handler.rb
+++ b/lib/action_mcp/server/transport_handler.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "pagination"
 require_relative "response_collector"
 require_relative "base_messaging"
 
@@ -11,6 +12,7 @@ module ActionMCP
       delegate :initialize!, :initialized?, to: :session
       delegate :read, :write, to: :session
 
+      include  Pagination
       include  MessagingService
       include  Capabilities
       include  Tools

--- a/test/integration/resources_list_test.rb
+++ b/test/integration/resources_list_test.rb
@@ -113,7 +113,7 @@ module ActionMCP
 
       assert_not_nil result["error"]
       assert_equal(-32_602, result["error"]["code"])
-      assert_match(/Invalid cursor value/, result["error"]["message"])
+      assert_match(/Invalid cursor/, result["error"]["message"])
     end
 
     test "resources/templates/list returns templates" do
@@ -183,7 +183,7 @@ module ActionMCP
 
       assert_not_nil result["error"]
       assert_equal(-32_602, result["error"]["code"])
-      assert_match(/Invalid cursor value/, result["error"]["message"])
+      assert_match(/Cursor must be a non-empty string/, result["error"]["message"])
     end
 
     test "resources/read returns MCP-compliant content shape" do

--- a/test/integration/tasks_integration_test.rb
+++ b/test/integration/tasks_integration_test.rb
@@ -144,6 +144,56 @@ class TasksIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal 13, body["result"]["tasks"].length
   end
 
+  test "tasks/list cursor follows recent ordering when ids and insert order diverge" do
+    original_page_size = ActionMCP.configuration.pagination_page_size
+    ActionMCP.configuration.pagination_page_size = 1
+    @session.tasks.delete_all
+
+    older = @session.tasks.create!(
+      id: "z-task",
+      request_method: "tools/call",
+      request_name: "older_task"
+    )
+    newer = @session.tasks.create!(
+      id: "a-task",
+      request_method: "tools/call",
+      request_name: "newer_task"
+    )
+
+    base_time = Time.zone.parse("2026-01-01 00:00:00 UTC")
+    older.update_columns(created_at: base_time, updated_at: base_time, last_updated_at: base_time)
+    newer.update_columns(created_at: base_time + 1.second, updated_at: base_time + 1.second, last_updated_at: base_time + 1.second)
+
+    post "/",
+         params: {
+           jsonrpc: "2.0",
+           id: "test-5a",
+           method: "tasks/list"
+         }.to_json,
+         headers: request_headers
+
+    assert_response :success
+    body = response.parsed_body
+    assert_equal [ newer.id ], body["result"]["tasks"].map { |task| task["id"] }
+    assert body["result"]["nextCursor"]
+
+    post "/",
+         params: {
+           jsonrpc: "2.0",
+           id: "test-5b",
+           method: "tasks/list",
+           params: { cursor: body["result"]["nextCursor"] }
+         }.to_json,
+         headers: request_headers
+
+    assert_response :success
+    body = response.parsed_body
+    assert_equal [ older.id ], body["result"]["tasks"].map { |task| task["id"] }
+    assert_nil body["result"]["nextCursor"]
+  ensure
+    ActionMCP.configuration.pagination_page_size = original_page_size
+  end
+
   # tasks/result tests
   test "tasks/result returns result for completed task" do
     post "/",

--- a/test/server/pagination_test.rb
+++ b/test/server/pagination_test.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionMCP
+  module Server
+    class PaginationTest < ActiveSupport::TestCase
+      # Test harness that includes the Pagination module
+      class PaginationHarness
+        include ActionMCP::Server::Pagination
+      end
+
+      setup do
+        @paginator = PaginationHarness.new
+        @items = (1..25).to_a
+      end
+
+      # --- Offset-based pagination ---
+
+      test "paginate returns all items when pagination is disabled and no cursor" do
+        ActionMCP.configuration.pagination_page_size = nil
+        items, next_cursor = @paginator.paginate(@items)
+
+        assert_equal @items, items
+        assert_nil next_cursor
+      end
+
+      test "paginate returns first page when enabled" do
+        ActionMCP.configuration.pagination_page_size = 10
+        items, next_cursor = @paginator.paginate(@items)
+
+        assert_equal (1..10).to_a, items
+        assert_not_nil next_cursor
+      ensure
+        ActionMCP.configuration.pagination_page_size = nil
+      end
+
+      test "paginate follows cursor to next page" do
+        ActionMCP.configuration.pagination_page_size = 10
+        _, first_cursor = @paginator.paginate(@items)
+        items, next_cursor = @paginator.paginate(@items, cursor: first_cursor)
+
+        assert_equal (11..20).to_a, items
+        assert_not_nil next_cursor
+      ensure
+        ActionMCP.configuration.pagination_page_size = nil
+      end
+
+      test "paginate returns last page without nextCursor" do
+        ActionMCP.configuration.pagination_page_size = 10
+        _, c1 = @paginator.paginate(@items)
+        _, c2 = @paginator.paginate(@items, cursor: c1)
+        items, next_cursor = @paginator.paginate(@items, cursor: c2)
+
+        assert_equal (21..25).to_a, items
+        assert_nil next_cursor
+      ensure
+        ActionMCP.configuration.pagination_page_size = nil
+      end
+
+      test "paginate with page_size override" do
+        items, next_cursor = @paginator.paginate(@items, page_size: 5, force: true)
+
+        assert_equal (1..5).to_a, items
+        assert_not_nil next_cursor
+      end
+
+      test "paginate with force: true ignores global setting" do
+        ActionMCP.configuration.pagination_page_size = nil
+        items, next_cursor = @paginator.paginate(@items, page_size: 10, force: true)
+
+        assert_equal (1..10).to_a, items
+        assert_not_nil next_cursor
+      end
+
+      test "paginate honors cursor even when pagination is disabled" do
+        ActionMCP.configuration.pagination_page_size = nil
+        # Manually create a cursor for offset 5
+        cursor = Base64.urlsafe_encode64("5", padding: false)
+        items, next_cursor = @paginator.paginate(@items, cursor: cursor)
+
+        # Should return items from offset 5, using DEFAULT_PAGE_SIZE (10)
+        assert_equal (6..15).to_a, items
+        assert_not_nil next_cursor, "Should have nextCursor since 20 items remain but page size is 10"
+      end
+
+      test "paginate raises CursorError for malformed cursor" do
+        assert_raises(CursorError) do
+          @paginator.paginate(@items, cursor: "not-base64!!!", force: true)
+        end
+      end
+
+      test "paginate raises CursorError for non-numeric cursor" do
+        cursor = Base64.urlsafe_encode64("abc", padding: false)
+        assert_raises(CursorError) do
+          @paginator.paginate(@items, cursor: cursor, force: true)
+        end
+      end
+
+      test "paginate raises CursorError for non-string cursor" do
+        assert_raises(CursorError) do
+          @paginator.paginate(@items, cursor: 123, force: true)
+        end
+      end
+
+      test "paginate returns empty array for offset beyond collection" do
+        cursor = Base64.urlsafe_encode64("999", padding: false)
+        items, next_cursor = @paginator.paginate(@items, cursor: cursor, force: true)
+
+        assert_equal [], items
+        assert_nil next_cursor
+      end
+
+      test "paginate with exact page size boundary" do
+        exact_items = (1..10).to_a
+        items, next_cursor = @paginator.paginate(exact_items, page_size: 10, force: true)
+
+        assert_equal exact_items, items
+        assert_nil next_cursor
+      end
+
+      # --- Keyset-based pagination ---
+
+      test "paginate_by_keyset raises CursorError for malformed cursor" do
+        assert_raises(CursorError) do
+          @paginator.paginate_by_keyset(
+            ActionMCP::Session::Task.none,
+            cursor: "garbage!!!"
+          )
+        end
+      end
+
+      test "paginate_by_keyset raises CursorError for empty cursor" do
+        assert_raises(CursorError) do
+          @paginator.paginate_by_keyset(
+            ActionMCP::Session::Task.none,
+            cursor: ""
+          )
+        end
+      end
+
+      # --- Config validation ---
+
+      test "pagination_page_size rejects non-positive values" do
+        assert_raises(ArgumentError) do
+          ActionMCP.configuration.pagination_page_size = 0
+        end
+
+        assert_raises(ArgumentError) do
+          ActionMCP.configuration.pagination_page_size = -5
+        end
+
+        assert_raises(ArgumentError) do
+          ActionMCP.configuration.pagination_page_size = "abc"
+        end
+      end
+
+      test "pagination_page_size accepts nil to disable" do
+        ActionMCP.configuration.pagination_page_size = nil
+        assert_nil ActionMCP.configuration.pagination_page_size
+      end
+
+      test "pagination_page_size accepts positive integer" do
+        ActionMCP.configuration.pagination_page_size = 50
+        assert_equal 50, ActionMCP.configuration.pagination_page_size
+      ensure
+        ActionMCP.configuration.pagination_page_size = nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Paginations is not used in most clients/harness.    

However when you want to fetch tools without blowing up memory usage  (especially in ruby), this become critical.


For ruby MCP client, i recommend @obie's [manceps](https://github.com/zarpay/manceps).