### PR TITLE
feat: add elicitation form and URL modes per MCP spec

### DIFF
--- a/lib/action_mcp/configuration.rb
+++ b/lib/action_mcp/configuration.rb
@@ -25,7 +25,6 @@ module ActionMCP
                   :logging_level,
                   :active_profile,
                   :profiles,
-                  :elicitation_enabled,
                   :verbose_logging,
                   # --- Authentication Options ---
                   :authentication_methods,
@@ -58,7 +57,6 @@ module ActionMCP
       @list_changed = true
       @logging_level = :warning
       @resources_subscribe = false
-      @elicitation_enabled = false
       @verbose_logging = false
       @active_profile = :primary
       @profiles = default_profiles
@@ -280,7 +278,6 @@ module ActionMCP
         capabilities[:resources] = { subscribe: @resources_subscribe, listChanged: @list_changed }
       end
 
-      capabilities[:elicitation] = {} if @elicitation_enabled
 
       # Tasks capability (MCP 2025-11-25)
       if @tasks_enabled

--- a/lib/action_mcp/server/elicitation.rb
+++ b/lib/action_mcp/server/elicitation.rb
@@ -1,58 +1,126 @@
 # frozen_string_literal: true
 
+require_relative "elicitation_request"
+require_relative "url_elicitation_request"
+
 module ActionMCP
   module Server
-    # Handles elicitation requests from the server to the client
+    # Handles elicitation requests from the server to the client.
+    #
+    # Two modes per MCP 2025-11-25:
+    #   - Form mode: structured data collection with JSON Schema validation
+    #   - URL mode: out-of-band interaction via external URL (sensitive data, OAuth flows)
     module Elicitation
-      # Sends an elicitation request to the client to gather additional information
-      # @param request_id [String, Integer] The JSON-RPC request ID
-      # @param message [String] The message to present to the user
-      # @param requested_schema [Hash] The schema for the requested information
-      # @return [Hash] The elicitation response
-      def send_elicitation_request(request_id, message:, requested_schema:)
-        # Validate the requested schema
-        validate_elicitation_schema!(requested_schema)
+      URL_ELICITATION_REQUIRED_CODE = -32_042
 
-        params = {
+      # Send a form mode elicitation request to the client.
+      # @param message [String] Human-readable message explaining why input is needed
+      # @param requested_schema [Hash] JSON Schema for the expected response (primitive types only)
+      # @param _meta [Hash] Optional metadata (e.g. related task)
+      def send_elicitation_create(message:, requested_schema:, _meta: {})
+        require_client_elicitation_support!(:form)
+
+        request = ElicitationRequest.new(
           message: message,
-          requestedSchema: requested_schema
+          requested_schema: requested_schema,
+          _meta: _meta
+        )
+        request.assert_valid!
+
+        send_jsonrpc_request("elicitation/create", params: request.to_params)
+      end
+
+      # Send a URL mode elicitation request to the client.
+      # Used for sensitive data collection (API keys, OAuth, payments) that must not
+      # pass through the MCP client.
+      # @param message [String] Human-readable message explaining why navigation is needed
+      # @param url [String] The URL the user should navigate to
+      # @param elicitation_id [String] Unique identifier for this elicitation
+      # @param _meta [Hash] Optional metadata (e.g. related task)
+      def send_elicitation_create_url(message:, url:, elicitation_id: nil, _meta: {})
+        require_client_elicitation_support!(:url)
+
+        request = UrlElicitationRequest.new(
+          message: message,
+          url: url,
+          elicitation_id: elicitation_id,
+          _meta: _meta
+        )
+        request.assert_valid!
+
+        send_jsonrpc_request("elicitation/create", params: request.to_params)
+      end
+
+      # Send a completion notification for a URL mode elicitation.
+      # Informs the client that the out-of-band interaction has completed.
+      # @param elicitation_id [String] The elicitation ID from the original request
+      def send_elicitation_complete_notification(elicitation_id)
+        require_client_elicitation_support!(:url)
+        send_jsonrpc_notification(
+          "notifications/elicitation/complete",
+          { elicitationId: elicitation_id }
+        )
+      end
+
+      # Build a URLElicitationRequiredError response (-32042).
+      # Used when a request cannot proceed until an elicitation is completed.
+      # @param request_id [String, Integer] The JSON-RPC request ID to respond to
+      # @param message [String] Human-readable error message
+      # @param elicitations [Array<Hash>] Required URL mode elicitations
+      def send_url_elicitation_required_error(request_id, message:, elicitations:)
+        require_client_elicitation_support!(:url)
+
+        elicitations.each do |e|
+          raise ArgumentError, "Each elicitation must have mode: 'url'" unless e[:mode] == "url"
+          raise ArgumentError, "Each elicitation must have an elicitationId" unless e[:elicitationId].present?
+
+          UrlElicitationRequest.new(
+            message: e[:message],
+            url: e[:url],
+            elicitation_id: e[:elicitationId]
+          ).assert_valid!
+        end
+
+        error = {
+          code: URL_ELICITATION_REQUIRED_CODE,
+          message: message,
+          data: { elicitations: elicitations }
         }
 
-        send_jsonrpc_request(request_id, method: "elicitation/create", params: params)
+        send_jsonrpc_response(request_id, error: error)
       end
 
       private
 
-      # Validates that the requested schema follows the elicitation constraints
-      # Only allows primitive types without nesting
-      def validate_elicitation_schema!(schema)
-        unless schema.is_a?(Hash) && schema[:type] == "object"
-          raise ArgumentError, "Elicitation schema must be an object type"
+      # Check that the client declared support for the given elicitation mode.
+      # Elicitation is a client capability — servers MUST NOT send modes the client didn't declare.
+      def require_client_elicitation_support!(mode)
+        client_caps = session.client_capabilities || {}
+        elicitation_caps = client_caps["elicitation"] || client_caps[:elicitation]
+
+        raise UnsupportedElicitationError, "Client does not support elicitation" unless elicitation_caps.is_a?(Hash)
+
+        if mode == :form
+          # Empty hash or explicit form: {} both mean form support (backward compat with 2025-06-18)
+          # But if client only declared url: {} without form, reject
+          form_cap = elicitation_caps["form"] || elicitation_caps[:form]
+          unless elicitation_caps.empty? || form_cap
+            raise UnsupportedElicitationError, "Client does not support form mode elicitation"
+          end
+          return
         end
 
-        properties = schema[:properties]
-        raise ArgumentError, "Elicitation schema must have properties" unless properties.is_a?(Hash)
-
-        properties.each do |key, prop_schema|
-          validate_primitive_schema!(key, prop_schema)
+        # URL mode requires protocol version 2025-11-25+
+        unless session.protocol_version == "2025-11-25"
+          raise UnsupportedElicitationError, "URL mode elicitation requires protocol version 2025-11-25"
         end
-      end
 
-      # Validates individual property schemas are primitive types
-      def validate_primitive_schema!(key, schema)
-        raise ArgumentError, "Property '#{key}' must have a schema definition" unless schema.is_a?(Hash)
-
-        type = schema[:type]
-        case type
-        when "string"
-          # Valid string schema, check for enums
-          raise ArgumentError, "Property '#{key}' enum must be an array" if schema[:enum] && !schema[:enum].is_a?(Array)
-        when "number", "integer", "boolean"
-          # Valid primitive types
-        else
-          raise ArgumentError, "Property '#{key}' must be a primitive type (string, number, integer, boolean)"
-        end
+        # Client must explicitly declare url mode support (empty hash = form-only for 2025-06-18 clients)
+        url_cap = elicitation_caps["url"] || elicitation_caps[:url]
+        raise UnsupportedElicitationError, "Client does not support URL mode elicitation" unless url_cap
       end
     end
+
+    class UnsupportedElicitationError < StandardError; end
   end
 end

--- a/lib/action_mcp/server/elicitation_request.rb
+++ b/lib/action_mcp/server/elicitation_request.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module ActionMCP
+  module Server
+    # Value object for form-mode elicitation requests.
+    # Validates that the requested schema follows MCP constraints:
+    # flat object with primitive properties only.
+    class ElicitationRequest
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :message, :string
+      attribute :requested_schema # Hash
+      attribute :_meta            # Hash, optional
+
+      validates :message, presence: true
+      validates :requested_schema, presence: true
+      validate :schema_must_be_object_with_properties, if: -> { requested_schema.present? }
+      validate :properties_must_be_primitive, if: -> { errors[:requested_schema].empty? && requested_schema.present? }
+
+      # Wrap incoming schema in indifferent access so both string and symbol keys work.
+      def requested_schema=(value)
+        super(value.is_a?(Hash) ? value.with_indifferent_access : value)
+      end
+
+      # @return [Hash] JSON-RPC params for elicitation/create
+      def to_params
+        params = { mode: "form", message: message, requestedSchema: requested_schema.to_hash.deep_symbolize_keys }
+        params[:_meta] = _meta if _meta.present?
+        params
+      end
+
+      # Validates and raises ArgumentError on failure (preserving public API).
+      # Named assert_valid! to avoid shadowing ActiveModel#validate!
+      def assert_valid!
+        return if valid?
+
+        raise ArgumentError, errors.full_messages.join(", ")
+      end
+
+      private
+
+      def schema_must_be_object_with_properties
+        unless requested_schema.is_a?(Hash) && requested_schema[:type] == "object"
+          errors.add(:requested_schema, "must be an object type")
+          return
+        end
+
+        properties = requested_schema[:properties]
+        errors.add(:requested_schema, "must have properties") unless properties.is_a?(Hash)
+      end
+
+      def properties_must_be_primitive
+        properties = requested_schema[:properties]
+        return unless properties.is_a?(Hash)
+
+        properties.each do |key, prop_schema|
+          validate_primitive_property(key, prop_schema)
+        end
+      end
+
+      def validate_primitive_property(key, schema)
+        unless schema.is_a?(Hash)
+          errors.add(:requested_schema, "property '#{key}' must have a schema definition")
+          return
+        end
+
+        case schema[:type]
+        when "string"
+          validate_string_enum(key, schema)
+        when "number", "integer", "boolean"
+          # valid primitive types
+        when "array"
+          validate_enum_array(key, schema)
+        else
+          errors.add(:requested_schema,
+            "property '#{key}' must be a primitive type (string, number, integer, boolean) or enum array")
+        end
+      end
+
+      def validate_string_enum(key, schema)
+        if schema[:enum] && !schema[:enum].is_a?(Array)
+          errors.add(:requested_schema, "property '#{key}' enum must be an array")
+        end
+      end
+
+      def validate_enum_array(key, schema)
+        items = schema[:items]
+        unless items.is_a?(Hash)
+          errors.add(:requested_schema, "property '#{key}' array must have items schema")
+          return
+        end
+
+        unless items[:enum].is_a?(Array) || items[:anyOf].is_a?(Array)
+          errors.add(:requested_schema, "property '#{key}' array items must be an enum (enum or anyOf)")
+        end
+      end
+    end
+  end
+end

--- a/lib/action_mcp/server/url_elicitation_request.rb
+++ b/lib/action_mcp/server/url_elicitation_request.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module ActionMCP
+  module Server
+    # Value object for URL-mode elicitation requests.
+    # Used for sensitive data collection (API keys, OAuth, payments)
+    # that must not pass through the MCP client.
+    class UrlElicitationRequest
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :message, :string
+      attribute :url, :string
+      attribute :elicitation_id, :string
+      attribute :_meta # Hash, optional
+
+      validates :message, presence: true
+      validates :url, presence: true
+      validate :url_must_be_valid_http, if: -> { url.present? }
+
+      def initialize(attributes = {})
+        super
+        self.elicitation_id = SecureRandom.uuid_v7 if elicitation_id.blank?
+      end
+
+      # @return [Hash] JSON-RPC params for elicitation/create
+      def to_params
+        params = {
+          mode: "url",
+          message: message,
+          url: url,
+          elicitationId: elicitation_id
+        }
+        params[:_meta] = _meta if _meta.present?
+        params
+      end
+
+      # Validates and raises ArgumentError on failure (preserving public API).
+      # Named assert_valid! to avoid shadowing ActiveModel#validate!
+      def assert_valid!
+        return if valid?
+
+        raise ArgumentError, errors.full_messages.join(", ")
+      end
+
+      private
+
+      def url_must_be_valid_http
+        parsed = URI.parse(url)
+        unless parsed.is_a?(URI::HTTP) && parsed.host.present?
+          errors.add(:url, "must be an HTTP or HTTPS URL with a host")
+        end
+      rescue URI::InvalidURIError
+        errors.add(:url, "is not a valid URI")
+      end
+    end
+  end
+end

--- a/test/fixtures/action_mcp_sessions.yml
+++ b/test/fixtures/action_mcp_sessions.yml
@@ -85,6 +85,100 @@ dr_identity_mcbouncer_session:
   created_at: <%= Time.now.utc.iso8601 %>
   updated_at: <%= Time.now.utc.iso8601 %>
 
+elicitation_form_session:
+  id: elicitation_form_session
+  role: server
+  status: initialized
+  initialized: true
+  protocol_version: "2025-06-18"
+  tool_registry:
+    - "*"
+  prompt_registry:
+    - "*"
+  resource_registry:
+    - "*"
+  consents: {}
+  messages_count: 0
+  client_capabilities:
+    elicitation: {}
+  server_capabilities:
+    tools:
+      listChanged: true
+    prompts:
+      listChanged: true
+    logging: {}
+    resources:
+      subscribe: false
+      listChanged: true
+  server_info:
+    name: "ActionMCP Dummy"
+    version: "9.9.9"
+  created_at: <%= Time.now.utc.iso8601 %>
+  updated_at: <%= Time.now.utc.iso8601 %>
+
+elicitation_url_session:
+  id: elicitation_url_session
+  role: server
+  status: initialized
+  initialized: true
+  protocol_version: "2025-11-25"
+  tool_registry:
+    - "*"
+  prompt_registry:
+    - "*"
+  resource_registry:
+    - "*"
+  consents: {}
+  messages_count: 0
+  client_capabilities:
+    elicitation:
+      form: {}
+      url: {}
+  server_capabilities:
+    tools:
+      listChanged: true
+    prompts:
+      listChanged: true
+    logging: {}
+    resources:
+      subscribe: false
+      listChanged: true
+  server_info:
+    name: "ActionMCP Dummy"
+    version: "9.9.9"
+  created_at: <%= Time.now.utc.iso8601 %>
+  updated_at: <%= Time.now.utc.iso8601 %>
+
+no_elicitation_session:
+  id: no_elicitation_session
+  role: server
+  status: initialized
+  initialized: true
+  protocol_version: "2025-06-18"
+  tool_registry:
+    - "*"
+  prompt_registry:
+    - "*"
+  resource_registry:
+    - "*"
+  consents: {}
+  messages_count: 0
+  client_capabilities: {}
+  server_capabilities:
+    tools:
+      listChanged: true
+    prompts:
+      listChanged: true
+    logging: {}
+    resources:
+      subscribe: false
+      listChanged: true
+  server_info:
+    name: "ActionMCP Dummy"
+    version: "9.9.9"
+  created_at: <%= Time.now.utc.iso8601 %>
+  updated_at: <%= Time.now.utc.iso8601 %>
+
 task_master_session:
   id: task_master_session
   role: server

--- a/test/server/elicitation_request_test.rb
+++ b/test/server/elicitation_request_test.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionMCP
+  module Server
+    class ElicitationRequestTest < ActiveSupport::TestCase
+      test "valid with correct schema" do
+        request = ElicitationRequest.new(
+          message: "What is your name?",
+          requested_schema: {
+            type: "object",
+            properties: { name: { type: "string" } },
+            required: [ "name" ]
+          }
+        )
+
+        assert request.valid?
+      end
+
+      test "to_params builds correct wire format" do
+        schema = { type: "object", properties: { name: { type: "string" } } }
+        request = ElicitationRequest.new(message: "Name?", requested_schema: schema)
+
+        params = request.to_params
+        assert_equal "form", params[:mode]
+        assert_equal "Name?", params[:message]
+        assert_equal schema, params[:requestedSchema]
+        assert_nil params[:_meta]
+      end
+
+      test "to_params includes _meta when present" do
+        request = ElicitationRequest.new(
+          message: "Name?",
+          requested_schema: { type: "object", properties: { name: { type: "string" } } },
+          _meta: { taskId: "task-1" }
+        )
+
+        assert_includes request.to_params, :_meta
+      end
+
+      test "invalid without message" do
+        request = ElicitationRequest.new(
+          requested_schema: { type: "object", properties: { name: { type: "string" } } }
+        )
+
+        assert_not request.valid?
+        assert_includes request.errors[:message], "can't be blank"
+      end
+
+      test "invalid without requested_schema" do
+        request = ElicitationRequest.new(message: "test")
+
+        assert_not request.valid?
+        assert_includes request.errors[:requested_schema], "can't be blank"
+      end
+
+      test "invalid when schema is not object type" do
+        request = ElicitationRequest.new(
+          message: "test",
+          requested_schema: { type: "string" }
+        )
+
+        assert_not request.valid?
+        assert request.errors[:requested_schema].any? { |e| e.include?("object type") }
+      end
+
+      test "invalid when schema has no properties" do
+        request = ElicitationRequest.new(
+          message: "test",
+          requested_schema: { type: "object" }
+        )
+
+        assert_not request.valid?
+        assert request.errors[:requested_schema].any? { |e| e.include?("properties") }
+      end
+
+      test "invalid with nested object property" do
+        request = ElicitationRequest.new(
+          message: "test",
+          requested_schema: {
+            type: "object",
+            properties: { nested: { type: "object", properties: {} } }
+          }
+        )
+
+        assert_not request.valid?
+        assert request.errors[:requested_schema].any? { |e| e.include?("primitive type") }
+      end
+
+      test "valid with string enum property" do
+        request = ElicitationRequest.new(
+          message: "Pick",
+          requested_schema: {
+            type: "object",
+            properties: { color: { type: "string", enum: %w[red green blue] } }
+          }
+        )
+
+        assert request.valid?
+      end
+
+      test "invalid when string enum is not an array" do
+        request = ElicitationRequest.new(
+          message: "Pick",
+          requested_schema: {
+            type: "object",
+            properties: { color: { type: "string", enum: "red" } }
+          }
+        )
+
+        assert_not request.valid?
+      end
+
+      test "valid with enum array using items enum" do
+        request = ElicitationRequest.new(
+          message: "Pick colors",
+          requested_schema: {
+            type: "object",
+            properties: {
+              colors: { type: "array", items: { type: "string", enum: %w[red green] } }
+            }
+          }
+        )
+
+        assert request.valid?
+      end
+
+      test "valid with enum array using anyOf" do
+        request = ElicitationRequest.new(
+          message: "Pick colors",
+          requested_schema: {
+            type: "object",
+            properties: {
+              colors: {
+                type: "array",
+                items: { anyOf: [ { const: "#FF0000", title: "Red" } ] }
+              }
+            }
+          }
+        )
+
+        assert request.valid?
+      end
+
+      test "invalid array without items schema" do
+        request = ElicitationRequest.new(
+          message: "Pick",
+          requested_schema: {
+            type: "object",
+            properties: { colors: { type: "array" } }
+          }
+        )
+
+        assert_not request.valid?
+        assert request.errors[:requested_schema].any? { |e| e.include?("items schema") }
+      end
+
+      test "valid with number, integer, and boolean properties" do
+        request = ElicitationRequest.new(
+          message: "Settings",
+          requested_schema: {
+            type: "object",
+            properties: {
+              count: { type: "integer" },
+              ratio: { type: "number" },
+              enabled: { type: "boolean" }
+            }
+          }
+        )
+
+        assert request.valid?
+      end
+
+      test "assert_valid! raises ArgumentError on invalid" do
+        request = ElicitationRequest.new(message: "test", requested_schema: { type: "string" })
+
+        error = assert_raises(ArgumentError) { request.assert_valid! }
+        assert_match(/object type/, error.message)
+      end
+
+      test "assert_valid! does not raise on valid" do
+        request = ElicitationRequest.new(
+          message: "Name?",
+          requested_schema: { type: "object", properties: { name: { type: "string" } } }
+        )
+
+        assert_nothing_raised { request.assert_valid! }
+      end
+
+      # --- String-keyed schema support (JSON-parsed hashes) ---
+
+      test "valid with string-keyed schema" do
+        request = ElicitationRequest.new(
+          message: "Name?",
+          requested_schema: {
+            "type" => "object",
+            "properties" => { "name" => { "type" => "string" } }
+          }
+        )
+
+        assert request.valid?
+      end
+
+      test "valid with mixed string and symbol keys in schema" do
+        request = ElicitationRequest.new(
+          message: "Pick",
+          requested_schema: {
+            "type" => "object",
+            "properties" => { color: { type: "string", "enum" => %w[red green] } }
+          }
+        )
+
+        assert request.valid?
+      end
+
+      test "rejects nested object even with string keys" do
+        request = ElicitationRequest.new(
+          message: "test",
+          requested_schema: {
+            "type" => "object",
+            "properties" => { "nested" => { "type" => "object", "properties" => {} } }
+          }
+        )
+
+        assert_not request.valid?
+      end
+    end
+  end
+end

--- a/test/server/elicitation_test.rb
+++ b/test/server/elicitation_test.rb
@@ -1,0 +1,280 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionMCP
+  module Server
+    class ElicitationTest < ActiveSupport::TestCase
+      fixtures :action_mcp_sessions
+
+      # --- Form mode ---
+
+      test "send_elicitation_create sends form mode request" do
+        transport = transport_for(:elicitation_form_session)
+        schema = {
+          type: "object",
+          properties: { name: { type: "string" } },
+          required: [ "name" ]
+        }
+
+        result = transport.send_elicitation_create(
+          message: "What is your name?",
+          requested_schema: schema
+        )
+
+        assert_equal "elicitation/create", result.method
+        assert_equal "form", result.params[:mode]
+        assert_equal "What is your name?", result.params[:message]
+        assert_equal schema, result.params[:requestedSchema]
+      end
+
+      test "send_elicitation_create validates schema must be object type" do
+        transport = transport_for(:elicitation_form_session)
+
+        assert_raises(ArgumentError) do
+          transport.send_elicitation_create(
+            message: "test",
+            requested_schema: { type: "string" }
+          )
+        end
+      end
+
+      test "send_elicitation_create validates schema must have properties" do
+        transport = transport_for(:elicitation_form_session)
+
+        assert_raises(ArgumentError) do
+          transport.send_elicitation_create(
+            message: "test",
+            requested_schema: { type: "object" }
+          )
+        end
+      end
+
+      test "send_elicitation_create rejects nested object properties" do
+        transport = transport_for(:elicitation_form_session)
+
+        assert_raises(ArgumentError) do
+          transport.send_elicitation_create(
+            message: "test",
+            requested_schema: {
+              type: "object",
+              properties: { nested: { type: "object", properties: {} } }
+            }
+          )
+        end
+      end
+
+      test "send_elicitation_create accepts enum array property" do
+        transport = transport_for(:elicitation_form_session)
+        schema = {
+          type: "object",
+          properties: {
+            colors: {
+              type: "array",
+              items: { type: "string", enum: %w[red green blue] }
+            }
+          }
+        }
+
+        result = transport.send_elicitation_create(message: "Pick colors", requested_schema: schema)
+        assert_equal "form", result.params[:mode]
+      end
+
+      test "send_elicitation_create accepts anyOf enum array property" do
+        transport = transport_for(:elicitation_form_session)
+        schema = {
+          type: "object",
+          properties: {
+            colors: {
+              type: "array",
+              items: {
+                anyOf: [
+                  { const: "#FF0000", title: "Red" },
+                  { const: "#00FF00", title: "Green" }
+                ]
+              }
+            }
+          }
+        }
+
+        result = transport.send_elicitation_create(message: "Pick colors", requested_schema: schema)
+        assert_equal "form", result.params[:mode]
+      end
+
+      # --- URL mode ---
+
+      test "send_elicitation_create_url sends url mode request" do
+        transport = transport_for(:elicitation_url_session)
+
+        result = transport.send_elicitation_create_url(
+          message: "Please provide your API key",
+          url: "https://example.com/auth",
+          elicitation_id: "test-123"
+        )
+
+        assert_equal "elicitation/create", result.method
+        assert_equal "url", result.params[:mode]
+        assert_equal "Please provide your API key", result.params[:message]
+        assert_equal "https://example.com/auth", result.params[:url]
+        assert_equal "test-123", result.params[:elicitationId]
+      end
+
+      test "send_elicitation_create_url generates elicitation_id when not provided" do
+        transport = transport_for(:elicitation_url_session)
+
+        result = transport.send_elicitation_create_url(
+          message: "Auth required",
+          url: "https://example.com/oauth"
+        )
+
+        assert_not_nil result.params[:elicitationId]
+      end
+
+      test "send_elicitation_create_url rejects empty url" do
+        transport = transport_for(:elicitation_url_session)
+
+        assert_raises(ArgumentError) do
+          transport.send_elicitation_create_url(message: "test", url: "")
+        end
+      end
+
+      test "send_elicitation_create_url rejects non-http url" do
+        transport = transport_for(:elicitation_url_session)
+
+        assert_raises(ArgumentError) do
+          transport.send_elicitation_create_url(message: "test", url: "ftp://example.com/file")
+        end
+      end
+
+      test "send_elicitation_create_url includes meta when provided" do
+        transport = transport_for(:elicitation_url_session)
+
+        result = transport.send_elicitation_create_url(
+          message: "Auth",
+          url: "https://example.com/auth",
+          _meta: { "io.modelcontextprotocol/related-task": { taskId: "task-1" } }
+        )
+
+        assert_not_nil result.params[:_meta]
+      end
+
+      # --- Completion notification ---
+
+      test "send_elicitation_complete_notification sends notification" do
+        transport = transport_for(:elicitation_url_session)
+
+        result = transport.send_elicitation_complete_notification("elicit-123")
+
+        assert_equal "notifications/elicitation/complete", result.method
+        assert_equal "elicit-123", result.params[:elicitationId]
+      end
+
+      # --- URLElicitationRequiredError ---
+
+      test "send_url_elicitation_required_error sends -32042 error" do
+        transport = transport_for(:elicitation_url_session)
+
+        result = transport.send_url_elicitation_required_error(
+          "req-1",
+          message: "Authorization required",
+          elicitations: [
+            {
+              mode: "url",
+              elicitationId: "e-1",
+              url: "https://example.com/connect",
+              message: "Connect your account"
+            }
+          ]
+        )
+
+        error = result.error
+        assert_equal(-32_042, error[:code])
+        assert_equal "Authorization required", error[:message]
+        assert_equal 1, error[:data][:elicitations].size
+        assert_equal "url", error[:data][:elicitations][0][:mode]
+      end
+
+      test "send_url_elicitation_required_error rejects non-url mode elicitations" do
+        transport = transport_for(:elicitation_url_session)
+
+        assert_raises(ArgumentError) do
+          transport.send_url_elicitation_required_error(
+            "req-1",
+            message: "Auth required",
+            elicitations: [ { mode: "form", message: "bad" } ]
+          )
+        end
+      end
+
+      test "send_url_elicitation_required_error rejects missing fields" do
+        transport = transport_for(:elicitation_url_session)
+
+        assert_raises(ArgumentError) do
+          transport.send_url_elicitation_required_error(
+            "req-1",
+            message: "Auth required",
+            elicitations: [ { mode: "url", url: "https://x.com", message: "go" } ]
+          )
+        end
+      end
+
+      # --- Client capability gating ---
+
+      test "send_elicitation_create raises when client has no elicitation support" do
+        transport = transport_for(:no_elicitation_session)
+
+        assert_raises(ActionMCP::Server::UnsupportedElicitationError) do
+          transport.send_elicitation_create(
+            message: "test",
+            requested_schema: { type: "object", properties: { name: { type: "string" } } }
+          )
+        end
+      end
+
+      test "send_elicitation_create_url raises on protocol 2025-06-18" do
+        transport = transport_for(:elicitation_form_session)
+
+        assert_raises(ActionMCP::Server::UnsupportedElicitationError) do
+          transport.send_elicitation_create_url(message: "test", url: "https://example.com/auth")
+        end
+      end
+
+      test "send_elicitation_create_url raises when client has no url mode support" do
+        # elicitation_form_session has elicitation: {} (form only) + protocol 2025-06-18
+        # Use a 2025-11-25 session with form-only caps
+        session = action_mcp_sessions(:task_master_session)
+        session.update!(client_capabilities: { "elicitation" => { "form" => {} } })
+        transport = ActionMCP::Server::TransportHandler.new(session, messaging_mode: :return)
+
+        assert_raises(ActionMCP::Server::UnsupportedElicitationError) do
+          transport.send_elicitation_create_url(message: "test", url: "https://example.com/auth")
+        end
+      end
+
+      test "send_elicitation_create works with form-only client" do
+        transport = transport_for(:elicitation_form_session)
+
+        result = transport.send_elicitation_create(
+          message: "Name?",
+          requested_schema: { type: "object", properties: { name: { type: "string" } } }
+        )
+
+        assert_equal "form", result.params[:mode]
+      end
+
+      # --- Elicitation is a client capability ---
+
+      test "server capabilities do not include elicitation" do
+        caps = ActionMCP.configuration.capabilities
+        assert_nil caps[:elicitation]
+      end
+
+      private
+
+      def transport_for(fixture_name)
+        session = action_mcp_sessions(fixture_name)
+        ActionMCP::Server::TransportHandler.new(session, messaging_mode: :return)
+      end
+    end
+  end
+end

--- a/test/server/url_elicitation_request_test.rb
+++ b/test/server/url_elicitation_request_test.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionMCP
+  module Server
+    class UrlElicitationRequestTest < ActiveSupport::TestCase
+      test "valid with https url" do
+        request = UrlElicitationRequest.new(
+          message: "Please authenticate",
+          url: "https://example.com/auth"
+        )
+
+        assert request.valid?
+      end
+
+      test "valid with http url" do
+        request = UrlElicitationRequest.new(
+          message: "Dev auth",
+          url: "http://localhost:3000/auth"
+        )
+
+        assert request.valid?
+      end
+
+      test "auto-generates elicitation_id when not provided" do
+        request = UrlElicitationRequest.new(
+          message: "Auth",
+          url: "https://example.com/auth"
+        )
+
+        assert_not_nil request.elicitation_id
+        assert request.elicitation_id.present?
+      end
+
+      test "preserves provided elicitation_id" do
+        request = UrlElicitationRequest.new(
+          message: "Auth",
+          url: "https://example.com/auth",
+          elicitation_id: "custom-id-123"
+        )
+
+        assert_equal "custom-id-123", request.elicitation_id
+      end
+
+      test "to_params builds correct wire format" do
+        request = UrlElicitationRequest.new(
+          message: "Auth needed",
+          url: "https://example.com/oauth",
+          elicitation_id: "e-1"
+        )
+
+        params = request.to_params
+        assert_equal "url", params[:mode]
+        assert_equal "Auth needed", params[:message]
+        assert_equal "https://example.com/oauth", params[:url]
+        assert_equal "e-1", params[:elicitationId]
+        assert_nil params[:_meta]
+      end
+
+      test "to_params includes _meta when present" do
+        request = UrlElicitationRequest.new(
+          message: "Auth",
+          url: "https://example.com/auth",
+          _meta: { taskId: "task-1" }
+        )
+
+        assert_includes request.to_params, :_meta
+      end
+
+      test "invalid without message" do
+        request = UrlElicitationRequest.new(url: "https://example.com/auth")
+
+        assert_not request.valid?
+        assert_includes request.errors[:message], "can't be blank"
+      end
+
+      test "invalid without url" do
+        request = UrlElicitationRequest.new(message: "test", url: "")
+
+        assert_not request.valid?
+        assert_includes request.errors[:url], "can't be blank"
+      end
+
+      test "invalid with ftp url" do
+        request = UrlElicitationRequest.new(
+          message: "test",
+          url: "ftp://example.com/file"
+        )
+
+        assert_not request.valid?
+        assert request.errors[:url].any? { |e| e.include?("HTTP") }
+      end
+
+      test "invalid with malformed url" do
+        request = UrlElicitationRequest.new(
+          message: "test",
+          url: "not a url at all %%"
+        )
+
+        assert_not request.valid?
+        assert request.errors[:url].any?
+      end
+
+      test "invalid with javascript url" do
+        request = UrlElicitationRequest.new(
+          message: "test",
+          url: "javascript:alert(1)"
+        )
+
+        assert_not request.valid?
+      end
+
+      test "invalid with hostless http url" do
+        request = UrlElicitationRequest.new(
+          message: "test",
+          url: "http://"
+        )
+
+        assert_not request.valid?
+        assert request.errors[:url].any? { |e| e.include?("host") }
+      end
+
+      test "invalid with scheme-only https url" do
+        request = UrlElicitationRequest.new(
+          message: "test",
+          url: "https://"
+        )
+
+        assert_not request.valid?
+      end
+
+      test "assert_valid! raises ArgumentError on invalid" do
+        request = UrlElicitationRequest.new(message: "test", url: "ftp://bad.com")
+
+        error = assert_raises(ArgumentError) { request.assert_valid! }
+        assert_match(/HTTP/, error.message)
+      end
+
+      test "assert_valid! does not raise on valid" do
+        request = UrlElicitationRequest.new(
+          message: "Auth",
+          url: "https://example.com/auth"
+        )
+
+        assert_nothing_raised { request.assert_valid! }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes the gap with the MCP specification by implementing the full elicitation flow.

Form mode (2025-06-18) enables servers to request structured input from users through the client. URL mode (2025-11-25) handles sensitive interactions — API keys, OAuth flows, payments — by directing users to external URLs without data passing through the MCP client.

Validation is handled by ActiveModel value objects rather than hand-rolled checks, and elicitation is correctly treated as a client capability rather than a server-advertised one.