### PR TITLE
fix: include Allow header in 405 response per RFC 9110

### DIFF
--- a/app/controllers/action_mcp/application_controller.rb
+++ b/app/controllers/action_mcp/application_controller.rb
@@ -34,6 +34,7 @@ module ActionMCP
     def show
       # MCP Streamable HTTP spec allows servers to return 405 if they don't support SSE.
       # ActionMCP uses Tasks for async operations instead of SSE streaming.
+      response.headers["Allow"] = "POST, DELETE"
       head :method_not_allowed
     end
 

--- a/test/integration/mcp_spec_validation_test.rb
+++ b/test/integration/mcp_spec_validation_test.rb
@@ -114,4 +114,11 @@ class McpSpecValidationTest < ActionDispatch::IntegrationTest
     # Verify tool response content
     assert_equal [ { "type" => "text", "text" => "Processed input: test" } ], body["result"]["content"]
   end
+
+  test "GET returns 405 with Allow header per RFC 9110" do
+    get "/"
+
+    assert_response :method_not_allowed
+    assert_equal "POST, DELETE", response.headers["Allow"]
+  end
 end


### PR DESCRIPTION
Fixes #209.

The MCP spec requires that a 405 response to GET on the MCP endpoint MUST include an `Allow` header listing supported methods (RFC 9110 §15.5.6). The fix is one line in `show`.

## Changes

- `app/controllers/action_mcp/application_controller.rb`: set `Allow: POST, DELETE` before `head :method_not_allowed`
- `test/integration/mcp_spec_validation_test.rb`: integration test asserting the header is present on GET