### PR TITLE
fix: render_ui(template:) works in API-only Rails hosts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
       - name: Run tests
         run: bin/rails test
 
+      - name: Run API-only host regression (edge only)
+        if: matrix.rails-version == 'dev'
+        env:
+          ACTION_MCP_API_ONLY: "1"
+        run: bin/rails test test/action_mcp/render_ui_api_only_test.rb
+
   test-sqlite3:
     name: Tests (SQLite3, Ruby ${{ matrix.ruby-version }}, Rails ${{ matrix.rails-version }})
     runs-on: ubuntu-latest
@@ -105,3 +111,9 @@ jobs:
 
       - name: Run tests
         run: bin/rails test
+
+      - name: Run API-only host regression (edge only)
+        if: matrix.rails-version == 'dev'
+        env:
+          ACTION_MCP_API_ONLY: "1"
+        run: bin/rails test test/action_mcp/render_ui_api_only_test.rb

--- a/app/controllers/action_mcp/mcp_app_renderer.rb
+++ b/app/controllers/action_mcp/mcp_app_renderer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ActionMCP
+  # Internal renderer for `ResourceTemplate#render_ui(template:)`, the entry
+  # point for MCP Apps UI views.
+  #
+  # Inherits from `ActionController::Base` so it always carries the full
+  # ActionView stack regardless of whether the host Rails app is API-only.
+  # Decoupling from the host's `ApplicationController` ensures `render_ui`
+  # produces a non-empty body under `config.api_only = true`.
+  #
+  # Note: templates rendered through this controller intentionally do NOT
+  # inherit host `ApplicationController` filters or `helper_method` exposure
+  # (e.g., `current_user`). That decoupling is what makes `render_ui` work in
+  # API-only hosts; reintroducing host coupling would bring the bug back.
+  # Pass any data the template needs via the `locals:` argument to
+  # `ResourceTemplate#render_ui`.
+  #
+  # Not routed. Not intended to be subclassed or used directly by host apps.
+  class MCPAppRenderer < ActionController::Base
+  end
+end

--- a/lib/action_mcp/resource_template.rb
+++ b/lib/action_mcp/resource_template.rb
@@ -343,7 +343,15 @@ module ActionMCP
         if text
           text
         elsif template
-          ApplicationController.render(template: template, layout: layout, locals: locals)
+          rendered = ActionMCP::MCPAppRenderer.render(template: template, layout: layout, locals: locals)
+          if rendered.to_s.strip.empty?
+            ActionMCP.logger.warn(
+              "[ActionMCP] render_ui produced empty output for #{self.class.name} " \
+              "(uri_template=#{self.class.uri_template.inspect}, template=#{template.inspect}). " \
+              "Check the template path and host view configuration."
+            )
+          end
+          rendered
         else
           raise ArgumentError, "render_ui requires :text or :template"
         end

--- a/test/action_mcp/render_ui_api_only_test.rb
+++ b/test/action_mcp/render_ui_api_only_test.rb
@@ -19,7 +19,7 @@ module ActionMCP
     include ActionMCP::TestHelper
 
     setup do
-      skip "Set ACTION_MCP_API_ONLY=1 to run API-only host regression" unless ENV["ACTION_MCP_API_ONLY"]
+      skip "Set ACTION_MCP_API_ONLY=1 to run API-only host regression" unless ENV["ACTION_MCP_API_ONLY"] == "1"
     end
 
     test "dummy ApplicationController is API-only in this run" do

--- a/test/action_mcp/render_ui_api_only_test.rb
+++ b/test/action_mcp/render_ui_api_only_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionMCP
+  # Regression coverage for the API-only host bug where
+  # `ResourceTemplate#render_ui(template:)` used to call the host's
+  # `::ApplicationController.render(...)` — which silently returned an empty
+  # body when the host was API-only (`ApplicationController < ActionController::API`).
+  #
+  # The fix routes rendering through `ActionMCP::MCPAppRenderer`, which owns the
+  # full ActionView stack regardless of host configuration.
+  #
+  # Gate this test with the env var so the default suite (full-Rails dummy)
+  # stays untouched. Run with:
+  #
+  #   ACTION_MCP_API_ONLY=1 bundle exec rails test test/action_mcp/render_ui_api_only_test.rb
+  class RenderUiApiOnlyTest < ActiveSupport::TestCase
+    include ActionMCP::TestHelper
+
+    setup do
+      skip "Set ACTION_MCP_API_ONLY=1 to run API-only host regression" unless ENV["ACTION_MCP_API_ONLY"]
+    end
+
+    test "dummy ApplicationController is API-only in this run" do
+      assert_operator ::ApplicationController, :<, ActionController::API,
+                      "Test environment is not booted in API-only mode"
+      refute_operator ::ApplicationController, :<, ActionController::Base,
+                      "ApplicationController should not inherit from ActionController::Base in API-only mode"
+    end
+
+    test "ActionMCP::MCPAppRenderer renders a template even when host ApplicationController is API-only" do
+      html = ActionMCP::MCPAppRenderer.render(template: "mcp/ui/weather_dashboard", layout: false)
+
+      refute html.to_s.strip.empty?, "MCPAppRenderer produced empty output in API-only host"
+      assert_includes html, "Weather"
+    end
+
+    test "render_ui(template:) returns non-empty content via WeatherDashboardTemplate in API-only host" do
+      response = resolve_mcp_resource("ui://weather/dashboard")
+      content = response.contents.first
+
+      refute_nil content, "expected at least one content entry"
+      refute content.text.to_s.strip.empty?, "render_ui produced empty text in API-only host"
+      assert_includes content.text, "Weather"
+    end
+  end
+end

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
-class ApplicationController < ActionController::Base
+# Set ACTION_MCP_API_ONLY=1 to boot the dummy app's ApplicationController as
+# API-only. Used by test/action_mcp/render_ui_api_only_test.rb to verify that
+# ActionMCP::MCPAppRenderer renders templates regardless of host view stack.
+# Explicit "1" check so accidental values like "0" or "false" don't enable it.
+ApplicationControllerParent = ENV["ACTION_MCP_API_ONLY"] == "1" ? ActionController::API : ActionController::Base
+
+class ApplicationController < ApplicationControllerParent
   # Standard authentication helpers for demonstration
   # These work alongside the Gateway authentication system
 
@@ -27,5 +33,5 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  helper_method :current_user, :user_signed_in?
+  helper_method :current_user, :user_signed_in? unless ENV["ACTION_MCP_API_ONLY"] == "1"
 end

--- a/test/dummy/app/controllers/sessions_controller.rb
+++ b/test/dummy/app/controllers/sessions_controller.rb
@@ -2,7 +2,9 @@
 
 # Session-based authentication controller for web applications
 class SessionsController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: [ :create, :destroy ]
+  # raise: false keeps the dummy boot-safe when ACTION_MCP_API_ONLY=1 swaps
+  # ApplicationController to ActionController::API (no CSRF callback to skip).
+  skip_before_action :verify_authenticity_token, only: [ :create, :destroy ], raise: false
 
   # <rails-lens:routes:begin>
   # ROUTE: /login, name: login, via: GET

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -2,7 +2,9 @@
 
 # User management controller for demonstration purposes
 class UsersController < ApplicationController
-  skip_before_action :verify_authenticity_token
+  # raise: false keeps the dummy boot-safe when ACTION_MCP_API_ONLY=1 swaps
+  # ApplicationController to ActionController::API (no CSRF callback to skip).
+  skip_before_action :verify_authenticity_token, raise: false
 
   # <rails-lens:routes:begin>
   # ROUTE: /users, name: users, via: POST


### PR DESCRIPTION
Route render_ui through ActionMCP::MCPAppRenderer (a gem-owned ActionController::Base subclass) instead of the host's ApplicationController. 

In API-only hosts the host's controller lacks the full ActionView stack, so render returned an empty body silently.