### PR TITLE
feat(tools): add alias_property support

### DIFF
--- a/TOOLS.MD
+++ b/TOOLS.MD
@@ -175,6 +175,30 @@ end
 - `"array"` - List of items
 - `"object"` - ⚠️ **Limited support** - See Input Schema Limitations below
 
+## Property Aliases
+
+Use `alias_property` when a tool should accept more than one input name for the same value:
+
+```ruby
+class SendMessageTool < ApplicationMCPTool
+  tool_name "send_message"
+  description "Send a message in a thread"
+
+  property :thread_id, type: "string", description: "Thread ID", required: true
+  alias_property :root_id, :thread_id
+  property :message, type: "string", description: "Message body", required: true
+
+  def perform
+    # root_id and thread_id read from the same underlying property
+    render(text: "Sending to #{thread_id}")
+  end
+end
+```
+
+Both `thread_id` and `root_id` are accepted when the tool is called. The canonical property
+stays in `inputSchema`, so `thread_id` remains the documented schema field while `root_id`
+works as a compatibility alias.
+
 ## ⚠️ Input Schema Limitations
 
 **Important:** The MCP specification currently only supports **flat, single-level** input schemas. While JSON Schema technically allows nested objects, the MCP spec intentionally keeps input parameters at one level.
@@ -959,7 +983,7 @@ end
 
 ### `schema_property_keys`
 
-Returns an array of string keys for all defined properties on a tool class. Useful for logging, debugging, or building dynamic tool wrappers:
+Returns an array of string keys for all accepted properties on a tool class, including aliases. Useful for logging, debugging, or building dynamic tool wrappers:
 
 ```ruby
 CalculateSumTool.schema_property_keys

--- a/lib/action_mcp/tool.rb
+++ b/lib/action_mcp/tool.rb
@@ -30,6 +30,7 @@ module ActionMCP
     class_attribute :_output_schema_builder, instance_accessor: false, default: nil
     class_attribute :_additional_properties, instance_accessor: false, default: nil
     class_attribute :_cached_schema_property_keys, instance_accessor: false, default: nil
+    class_attribute :_property_aliases, instance_accessor: false, default: {}
     class_attribute :_task_support, instance_accessor: false, default: :forbidden
     class_attribute :_resumable_steps_block, instance_accessor: false, default: nil
 
@@ -296,16 +297,46 @@ module ActionMCP
       def schema_property_keys
         return _cached_schema_property_keys if _cached_schema_property_keys
 
-        self._cached_schema_property_keys = _schema_properties.keys.map(&:to_s)
+        self._cached_schema_property_keys = (_schema_properties.keys + _property_aliases.keys).map(&:to_s)
         _cached_schema_property_keys
       end
 
-      # Clear cached keys when properties change - use metaprogramming to avoid duplication
-      [ :property, :collection ].each do |method_name|
-        define_method(method_name) do |prop_name, **opts|
-          invalidate_schema_cache
-          super(prop_name, **opts)
+      # Creates an alternate input name for an existing property.
+      #
+      # @example
+      #   property :thread_id, type: "string", required: true
+      #   alias_property :root_id, :thread_id
+      #
+      # Both `root_id` and `thread_id` are accepted when initializing the tool,
+      # and both readers resolve to the same ActiveModel attribute.
+      def alias_property(alias_name, property_name)
+        alias_key = alias_name.to_s
+        property_key = canonical_property_name(property_name)
+
+        unless _schema_properties.key?(property_key)
+          raise ArgumentError, "Cannot alias unknown property '#{property_name}'"
         end
+
+        if alias_key == property_key
+          raise ArgumentError, "Cannot alias property '#{property_key}' to itself"
+        end
+
+        if _schema_properties.key?(alias_key)
+          raise ArgumentError, "Cannot alias '#{alias_key}' because it is already defined as a property"
+        end
+
+        existing_alias = _property_aliases[alias_key]
+        if existing_alias && existing_alias != property_key
+          raise ArgumentError, "Alias '#{alias_key}' already points to property '#{existing_alias}'"
+        end
+
+        self._property_aliases = _property_aliases.merge(alias_key => property_key)
+        alias_attribute alias_key, property_key
+        invalidate_schema_cache
+      end
+
+      def canonical_property_name(name)
+        _property_aliases[name.to_s] || name.to_s
       end
 
       private
@@ -332,6 +363,12 @@ module ActionMCP
     # @param opts [Hash] Additional options for the JSON Schema.
     # @return [void]
     def self.property(prop_name, type: "string", description: nil, required: false, default: nil, **opts)
+      if _property_aliases.key?(prop_name.to_s)
+        raise ArgumentError, "Cannot define property '#{prop_name}' because it is already defined as an alias"
+      end
+
+      invalidate_schema_cache
+
       # Build the JSON Schema definition.
       prop_definition = { type: type }
       prop_definition[:description] = description if description && !description.empty?
@@ -364,6 +401,12 @@ module ActionMCP
     # @return [void]
     def self.collection(prop_name, type:, description: nil, required: false, default: [])
       raise ArgumentError, "Type is required for a collection" if type.nil?
+
+      if _property_aliases.key?(prop_name.to_s)
+        raise ArgumentError, "Cannot define collection '#{prop_name}' because it is already defined as an alias"
+      end
+
+      invalidate_schema_cache
 
       collection_definition = { type: "array", items: { type: type } }
       collection_definition[:description] = description if description && !description.empty?
@@ -443,6 +486,8 @@ module ActionMCP
 
     # Override initialize to validate parameters before ActiveModel conversion
     def initialize(attributes = {})
+      validate_property_alias_conflicts(attributes)
+
       # Separate additional properties from defined attributes if enabled
       if self.class.accepts_additional_properties?
         defined_keys = self.class.schema_property_keys
@@ -647,20 +692,43 @@ module ActionMCP
 
     private
 
+    def validate_property_alias_conflicts(attributes)
+      return unless attributes.is_a?(Hash)
+
+      seen_values = {}
+      seen_keys = {}
+
+      attributes.each do |key, value|
+        key_str = key.to_s
+        property_key = self.class.canonical_property_name(key_str)
+        next unless self.class._schema_properties.key?(property_key)
+
+        if seen_values.key?(property_key) && seen_keys[property_key] != key_str && seen_values[property_key] != value
+          raise ArgumentError,
+                "Conflicting values provided for aliased property '#{property_key}' " \
+                "via '#{seen_keys[property_key]}' and '#{key_str}'"
+        end
+
+        seen_values[property_key] = value
+        seen_keys[property_key] = key_str
+      end
+    end
+
     # Validates parameter types before ActiveModel conversion
     def validate_parameter_types(attributes)
       return unless attributes.is_a?(Hash)
 
       attributes.each do |key, value|
         key_str = key.to_s
-        property_schema = self.class._schema_properties[key_str]
+        property_key = self.class.canonical_property_name(key_str)
+        property_schema = self.class._schema_properties[property_key]
 
         next unless property_schema
 
         expected_type = property_schema[:type]
 
         # Skip validation if value is nil and property is not required
-        next if value.nil? && !self.class._required_properties.include?(key_str)
+        next if value.nil? && !self.class._required_properties.include?(property_key)
 
         # Validate based on expected JSON Schema type
         case expected_type

--- a/test/action_mcp/tool_alias_property_test.rb
+++ b/test/action_mcp/tool_alias_property_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionMCP::ToolAliasPropertyTest < ActiveSupport::TestCase
+  test "alias_property accepts alternate parameter names for the same property" do
+    tool_class = Class.new(ActionMCP::Tool) do
+      tool_name "alias_property_message"
+      description "Tool with aliased thread parameter"
+
+      property :thread_id, type: "string", required: true
+      alias_property :root_id, :thread_id
+
+      def perform
+        render text: thread_id
+      end
+    end
+
+    tool = tool_class.new(root_id: "thread-123")
+
+    assert tool.valid?
+    assert_equal "thread-123", tool.thread_id
+    assert_equal "thread-123", tool.root_id
+    assert_equal({ "thread_id" => "thread-123" }, tool.attributes)
+
+    response = tool_class.call(root_id: "thread-123")
+
+    refute response.error?
+    assert_equal "thread-123", response.contents.first.text
+  end
+
+  test "alias_property keeps aliases out of additional_params" do
+    tool_class = Class.new(ActionMCP::Tool) do
+      tool_name "alias_property_additional_params"
+      description "Tool with aliased params and additional params"
+
+      property :thread_id, type: "string", required: true
+      alias_property :root_id, :thread_id
+      additional_properties true
+    end
+
+    tool = tool_class.new("root_id" => "thread-123", "metadata" => "value")
+
+    assert_equal "thread-123", tool.thread_id
+    assert_equal({ "metadata" => "value" }, tool.additional_params)
+    assert_includes tool_class.schema_property_keys, "root_id"
+  end
+
+  test "alias_property validates aliased values against the target property type" do
+    tool_class = Class.new(ActionMCP::Tool) do
+      tool_name "alias_property_type_validation"
+      description "Tool with numeric aliased param"
+
+      property :thread_id, type: "number", required: true
+      alias_property :root_id, :thread_id
+    end
+
+    error = assert_raises(ArgumentError) do
+      tool_class.new(root_id: "not-a-number")
+    end
+
+    assert_match(/root_id/, error.message)
+    assert_match(/must be a valid number/, error.message)
+  end
+
+  test "alias_property rejects conflicting canonical and alias values" do
+    tool_class = Class.new(ActionMCP::Tool) do
+      tool_name "alias_property_conflict"
+      description "Tool with conflicting aliased params"
+
+      property :thread_id, type: "string", required: true
+      alias_property :root_id, :thread_id
+    end
+
+    error = assert_raises(ArgumentError) do
+      tool_class.new(thread_id: "thread-123", root_id: "thread-456")
+    end
+
+    assert_match(/Conflicting values/, error.message)
+    assert_match(/thread_id/, error.message)
+    assert_match(/root_id/, error.message)
+  end
+
+  test "alias_property requires an existing target property" do
+    error = assert_raises(ArgumentError) do
+      Class.new(ActionMCP::Tool) do
+        tool_name "alias_property_unknown_target"
+        description "Tool with invalid alias"
+
+        alias_property :root_id, :thread_id
+      end
+    end
+
+    assert_match(/unknown property 'thread_id'/, error.message)
+  end
+
+  test "property cannot reuse an existing alias name" do
+    error = assert_raises(ArgumentError) do
+      Class.new(ActionMCP::Tool) do
+        tool_name "alias_property_reused_alias"
+        description "Tool with duplicate alias and property"
+
+        property :thread_id, type: "string", required: true
+        alias_property :root_id, :thread_id
+        property :root_id, type: "string"
+      end
+    end
+
+    assert_match(/already defined as an alias/, error.message)
+  end
+
+  test "alias_property does not duplicate the canonical input schema property" do
+    tool_class = Class.new(ActionMCP::Tool) do
+      tool_name "alias_property_schema"
+      description "Tool with canonical schema"
+
+      property :thread_id, type: "string", required: true
+      alias_property :root_id, :thread_id
+    end
+
+    schema = tool_class.to_h[:inputSchema]
+
+    assert_includes schema[:properties], "thread_id"
+    refute_includes schema[:properties], "root_id"
+    assert_equal [ "thread_id" ], schema[:required]
+  end
+end


### PR DESCRIPTION
This pull request introduces support for property aliases in the `ActionMCP::Tool` framework, allowing tools to accept multiple input names for the same property. This improves compatibility and flexibility when integrating with different clients or legacy APIs. The implementation includes new methods, validation logic, documentation, and comprehensive tests to ensure correct behavior and error handling.
